### PR TITLE
Fix of implementation of SyrecSynthesis::increase operation

### DIFF
--- a/include/algorithms/synthesis/syrec_synthesis.hpp
+++ b/include/algorithms/synthesis/syrec_synthesis.hpp
@@ -105,7 +105,6 @@ namespace syrec {
         static bool  equals(AnnotatableQuantumComputation& annotatableQuantumComputation, qc::Qubit dest, const std::vector<qc::Qubit>& src1, const std::vector<qc::Qubit>& src2);                       // =
         static bool  greaterEquals(AnnotatableQuantumComputation& annotatableQuantumComputation, qc::Qubit dest, const std::vector<qc::Qubit>& srcTwo, const std::vector<qc::Qubit>& srcOne);            // >
         static bool  greaterThan(AnnotatableQuantumComputation& annotatableQuantumComputation, qc::Qubit dest, const std::vector<qc::Qubit>& src2, const std::vector<qc::Qubit>& src1);                  // >// +=
-        static bool  increaseWithCarry(AnnotatableQuantumComputation& annotatableQuantumComputation, const std::vector<qc::Qubit>& dest, const std::vector<qc::Qubit>& src, qc::Qubit carry);
         static bool  lessEquals(AnnotatableQuantumComputation& annotatableQuantumComputation, qc::Qubit dest, const std::vector<qc::Qubit>& src2, const std::vector<qc::Qubit>& src1);                         // <=
         static bool  lessThan(AnnotatableQuantumComputation& annotatableQuantumComputation, qc::Qubit dest, const std::vector<qc::Qubit>& src1, const std::vector<qc::Qubit>& src2);                           // <
         static bool  modulo(AnnotatableQuantumComputation& annotatableQuantumComputation, const std::vector<qc::Qubit>& dest, const std::vector<qc::Qubit>& src1, const std::vector<qc::Qubit>& src2);         // %
@@ -113,7 +112,7 @@ namespace syrec {
         static bool  notEquals(AnnotatableQuantumComputation& annotatableQuantumComputation, qc::Qubit dest, const std::vector<qc::Qubit>& src1, const std::vector<qc::Qubit>& src2);                          // !=
         static bool  swap(AnnotatableQuantumComputation& annotatableQuantumComputation, const std::vector<qc::Qubit>& dest1, const std::vector<qc::Qubit>& dest2);                                             // NOLINT(cppcoreguidelines-noexcept-swap, performance-noexcept-swap) <=>
         static bool  decrease(AnnotatableQuantumComputation& annotatableQuantumComputation, const std::vector<qc::Qubit>& rhs, const std::vector<qc::Qubit>& lhs);
-        static bool  increase(AnnotatableQuantumComputation& annotatableQuantumComputation, const std::vector<qc::Qubit>& rhs, const std::vector<qc::Qubit>& lhs);
+        static bool  increase(AnnotatableQuantumComputation& annotatableQuantumComputation, const std::vector<qc::Qubit>& rhs, const std::vector<qc::Qubit>& lhs, const std::optional<qc::Qubit>& optionalCarryOut = std::nullopt);
         virtual bool expressionOpInverse([[maybe_unused]] BinaryExpression::BinaryOperation binaryOperation, [[maybe_unused]] const std::vector<qc::Qubit>& expLhs, [[maybe_unused]] const std::vector<qc::Qubit>& expRhs);
         bool         checkRepeats();
 

--- a/src/algorithms/synthesis/syrec_synthesis.cpp
+++ b/src/algorithms/synthesis/syrec_synthesis.cpp
@@ -484,7 +484,6 @@ namespace syrec {
         // thus the comparison between the elements was possible. Since we are now storing the scoped enum values instead, we need to separately handle binary and assignment operations when
         // comparing the two types with the latter requiring a conversion to determine its matching binary operation counterpart. While the scoped enum values can be converted to their underlying
         // numeric data type (or any other type), they require an explicit cast instead.
-        // TODO: Temporarily commented out due to changes in synthesis in line aware synthesis preventing the creation of subassignments to determine errors in the algorithm
         if (expOpp.size() == opVec.size()) {
             if (std::holds_alternative<BinaryExpression::BinaryOperation>(operationVariant) && expOpp.top() == std::get<BinaryExpression::BinaryOperation>(operationVariant)) {
                 return true;

--- a/src/algorithms/synthesis/syrec_synthesis.cpp
+++ b/src/algorithms/synthesis/syrec_synthesis.cpp
@@ -796,10 +796,9 @@ namespace syrec {
         const auto&       a        = lhs;
         const auto&       b        = rhs;
 
-        // TODO: Is result (a + b) mod 2^(bitwidth - 1)
-        // Implementation of the addition algorithm defined in the paper "Quantum Addition Circuits and Unbounded Fan-Out" (https://arxiv.org/abs/0910.2530v1)
-        // that is based on a ripple-carry adder and requires no ancillary qubits.  The sum of the two input operands 'a' and 'b' is stored in the qubits of
-        // operand 'b' (i.e. the right-hand side operand of the expression (a + b)). We will use N to denote the bitwidth of the operands in the description of the steps of the algorithm.
+        // Implementation of the addition algorithm (a + b) mod N (N > 1) defined in the paper "Quantum Addition Circuits and Unbounded Fan-Out" (https://arxiv.org/abs/0910.2530v1)
+        // based on a ripple-carry adder that requires no ancillary qubits. The sum of the two input operands 'a' and 'b' is stored in the qubits of the operand 'b'
+        // (i.e. the right-hand side operand of the expression (a + b)). We will use N to denote the bitwidth of the operands in the description of the steps of the algorithm.
 
         // 1. Calculcate the terms (a_i XOR b_i) for all 0 < i < N and store results in b_i as CNOT(control: a_i, target: b_i)
         for (std::size_t i = 1; i < bitwidth && synthesisOk; ++i) {
@@ -819,7 +818,7 @@ namespace syrec {
             synthesisOk = annotatableQuantumComputation.addOperationsImplementingToffoliGate(b[i], a[i], a[i + 1]);
         }
 
-        // Optionally calculate the value of carry out qubit 
+        // Optionally calculate the value of carry out qubit
         synthesisOk &= !optionalCarryOut.has_value() || annotatableQuantumComputation.addOperationsImplementingToffoliGate(a[bitwidth - 1], b[bitwidth - 1], *optionalCarryOut);
 
         // 4. Calculate term (b_i XOR c_i) of the final sum terms (a_i XOR b_i XOR c_i) and "remove" the carry bit values from the lines (a_(i - 1)) storing the backup values of a_i for all N > i > 0:

--- a/src/algorithms/synthesis/syrec_synthesis.cpp
+++ b/src/algorithms/synthesis/syrec_synthesis.cpp
@@ -792,30 +792,43 @@ namespace syrec {
         }
 
         const std::size_t bitwidth = rhs.size();
-        for (std::size_t i = 1; i <= bitwidth - 1 && synthesisOk; ++i) {
-            synthesisOk = annotatableQuantumComputation.addOperationsImplementingCnotGate(lhs[i], rhs[i]);
+        const auto&       a        = lhs;
+        const auto&       b        = rhs;
+
+        // Reference algorithm is defined in paper "Quantum Addition Circuits and Unbounded Fan-Out" (https://arxiv.org/abs/0910.2530v1)
+        // s_i = (a_i XOR b_i) XOR c_(i - 1)
+        // c_i = ((a_i XOR b_i) AND c_(i - 1)) OR (a_i AND b_i)
+        // c_0 = 0 and c_n is not of interest
+        // Implementation is based on the algorithm proposed in the paper "Quantum Addition Circuits and Unbounded Fan-Out"
+
+        // 1.
+        for (std::size_t i = 1; i < bitwidth && synthesisOk; ++i) {
+            synthesisOk = annotatableQuantumComputation.addOperationsImplementingCnotGate(a[i], b[i]);
         }
 
-        for (std::size_t i = bitwidth - 2; i >= 1 && synthesisOk; --i) {
-            synthesisOk = annotatableQuantumComputation.addOperationsImplementingCnotGate(lhs[i], rhs[i]);
+        // 2.
+        for (std::size_t i = bitwidth - 1; i > 1 && synthesisOk; --i) {
+            synthesisOk = annotatableQuantumComputation.addOperationsImplementingCnotGate(a[i - 1], a[i]);
         }
 
-        for (std::size_t i = 0; i <= bitwidth - 2 && synthesisOk; ++i) {
-            synthesisOk = annotatableQuantumComputation.addOperationsImplementingToffoliGate(rhs[i], lhs[i], lhs[i + 1]);
+        // 3.
+        for (std::size_t i = 0; i < bitwidth - 1 && synthesisOk; ++i) {
+            synthesisOk = annotatableQuantumComputation.addOperationsImplementingToffoliGate(b[i], a[i], a[i + 1]);
         }
 
-        synthesisOk &= annotatableQuantumComputation.addOperationsImplementingCnotGate(lhs[bitwidth - 1], rhs[bitwidth - 1]);
-        for (std::size_t i = bitwidth - 2; i >= 1 && synthesisOk; --i) {
-            synthesisOk = annotatableQuantumComputation.addOperationsImplementingToffoliGate(lhs[i], rhs[i], lhs[i + 1]) && annotatableQuantumComputation.addOperationsImplementingCnotGate(lhs[i], rhs[i]);
-        }
-        synthesisOk &= annotatableQuantumComputation.addOperationsImplementingToffoliGate(lhs.front(), rhs.front(), lhs[1]) && annotatableQuantumComputation.addOperationsImplementingCnotGate(lhs.front(), rhs.front());
-
-        for (std::size_t i = 1; i <= bitwidth - 2 && synthesisOk; ++i) {
-            synthesisOk = annotatableQuantumComputation.addOperationsImplementingCnotGate(lhs[i], rhs[i + 1]);
+        // 4.
+        for (std::size_t i = bitwidth - 1; i > 0 && synthesisOk; --i) {
+            synthesisOk = annotatableQuantumComputation.addOperationsImplementingCnotGate(a[i], b[i]) && annotatableQuantumComputation.addOperationsImplementingToffoliGate(a[i - 1], b[i - 1], a[i]);
         }
 
-        for (std::size_t i = 1; i <= bitwidth - 1 && synthesisOk; ++i) {
-            synthesisOk = annotatableQuantumComputation.addOperationsImplementingCnotGate(lhs[i], rhs[i]);
+        // 5.
+        for (std::size_t i = 1; i < bitwidth - 1 && synthesisOk; ++i) {
+            synthesisOk = annotatableQuantumComputation.addOperationsImplementingCnotGate(a[i], a[i + 1]);
+        }
+
+        // 6.
+        for (std::size_t i = bitwidth; i > 0 && synthesisOk; --i) {
+            synthesisOk = annotatableQuantumComputation.addOperationsImplementingCnotGate(a[i - 1], b[i - 1]);
         }
         return synthesisOk;
     }

--- a/src/algorithms/synthesis/syrec_synthesis.cpp
+++ b/src/algorithms/synthesis/syrec_synthesis.cpp
@@ -795,38 +795,39 @@ namespace syrec {
         const auto&       a        = lhs;
         const auto&       b        = rhs;
 
-        // Reference algorithm is defined in paper "Quantum Addition Circuits and Unbounded Fan-Out" (https://arxiv.org/abs/0910.2530v1)
-        // s_i = (a_i XOR b_i) XOR c_(i - 1)
-        // c_i = ((a_i XOR b_i) AND c_(i - 1)) OR (a_i AND b_i)
-        // c_0 = 0 and c_n is not of interest
-        // Implementation is based on the algorithm proposed in the paper "Quantum Addition Circuits and Unbounded Fan-Out"
+        // Implementation of the algorithm defined in the paper "Quantum Addition Circuits and Unbounded Fan-Out" (https://arxiv.org/abs/0910.2530v1) that is
+        // based on a ripple-carry adder and requires no ancillary qubits. No input carry is supported and the carry for the n-th qubit is not calculcated.
+        // The sum of the two input operands 'a' and 'b' is stored in the qubits of operand 'b' (i.e. the right-hand side operand of the expression (a + b)).
+        // We will use N to denote the bitwidth of the operands in the description of the steps of the algorithm.
 
-        // 1.
+        // 1. Calculcate the terms (a_i XOR b_i) for all 0 < i < N and store results in b_i as CNOT(control: a_i, target: b_i)
         for (std::size_t i = 1; i < bitwidth && synthesisOk; ++i) {
             synthesisOk = annotatableQuantumComputation.addOperationsImplementingCnotGate(a[i], b[i]);
         }
 
-        // 2.
+        // 2. For every N > i > 0 store a backup of a_(i - 1) into a_i as CNOT(control: a_(i - 1), target: a_i)
         for (std::size_t i = bitwidth - 1; i > 1 && synthesisOk; --i) {
             synthesisOk = annotatableQuantumComputation.addOperationsImplementingCnotGate(a[i - 1], a[i]);
         }
 
-        // 3.
+        // 3. Calculate the carry bits and store them in a_i for every 0 <= i < (N - 1) as TOFFOLI(controls: {b_i, a_i}, target: a_(i + 1))
         for (std::size_t i = 0; i < bitwidth - 1 && synthesisOk; ++i) {
             synthesisOk = annotatableQuantumComputation.addOperationsImplementingToffoliGate(b[i], a[i], a[i + 1]);
         }
 
-        // 4.
+        // 4. Calculate term (b_i XOR c_i) of the final sum terms (a_i XOR b_i XOR c_i) and "remove" the carry bit values from the lines (a_(i - 1)) storing the backup values of a_i for all N > i > 0:
+        //    - CNOT(control: a_i, b_i)
+        //    - TOFFOLI(controls: {a_(i - 1), b_(i - 1)}, target: a_i)
         for (std::size_t i = bitwidth - 1; i > 0 && synthesisOk; --i) {
             synthesisOk = annotatableQuantumComputation.addOperationsImplementingCnotGate(a[i], b[i]) && annotatableQuantumComputation.addOperationsImplementingToffoliGate(a[i - 1], b[i - 1], a[i]);
         }
 
-        // 5.
+        // 5. Restore the backup values storing in (a_(i - 1)) back to a_i as: 0 < i < N - 1: CNOT(control: a_i, target: a_(i + 1))
         for (std::size_t i = 1; i < bitwidth - 1 && synthesisOk; ++i) {
             synthesisOk = annotatableQuantumComputation.addOperationsImplementingCnotGate(a[i], a[i + 1]);
         }
 
-        // 6.
+        // 6. Calculate the final sum terms as: N > i > 0: CNOT(control: a_i, b_i)
         for (std::size_t i = bitwidth; i > 0 && synthesisOk; --i) {
             synthesisOk = annotatableQuantumComputation.addOperationsImplementingCnotGate(a[i - 1], b[i - 1]);
         }

--- a/src/algorithms/synthesis/syrec_synthesis.cpp
+++ b/src/algorithms/synthesis/syrec_synthesis.cpp
@@ -484,6 +484,7 @@ namespace syrec {
         // thus the comparison between the elements was possible. Since we are now storing the scoped enum values instead, we need to separately handle binary and assignment operations when
         // comparing the two types with the latter requiring a conversion to determine its matching binary operation counterpart. While the scoped enum values can be converted to their underlying
         // numeric data type (or any other type), they require an explicit cast instead.
+        // TODO: Temporarily commented out due to changes in synthesis in line aware synthesis preventing the creation of subassignments to determine errors in the algorithm
         if (expOpp.size() == opVec.size()) {
             if (std::holds_alternative<BinaryExpression::BinaryOperation>(operationVariant) && expOpp.top() == std::get<BinaryExpression::BinaryOperation>(operationVariant)) {
                 return true;
@@ -691,7 +692,7 @@ namespace syrec {
             synthesisOk = annotatableQuantumComputation.addOperationsImplementingNotGate(dest[i]);
         }
 
-        synthesisOk &= increaseWithCarry(annotatableQuantumComputation, dest, src, carry);
+        synthesisOk &= increase(annotatableQuantumComputation, dest, src, carry);
         for (std::size_t i = 0; i < src.size() && synthesisOk; ++i) {
             synthesisOk = annotatableQuantumComputation.addOperationsImplementingNotGate(dest[i]);
         }
@@ -776,7 +777,7 @@ namespace syrec {
         return lessThan(annotatableQuantumComputation, dest, src1, src2);
     }
 
-    bool SyrecSynthesis::increase(AnnotatableQuantumComputation& annotatableQuantumComputation, const std::vector<qc::Qubit>& rhs, const std::vector<qc::Qubit>& lhs) {
+    bool SyrecSynthesis::increase(AnnotatableQuantumComputation& annotatableQuantumComputation, const std::vector<qc::Qubit>& rhs, const std::vector<qc::Qubit>& lhs, const std::optional<qc::Qubit>& optionalCarryOut) {
         if (lhs.size() != rhs.size()) {
             return false;
         }
@@ -795,15 +796,18 @@ namespace syrec {
         const auto&       a        = lhs;
         const auto&       b        = rhs;
 
-        // Implementation of the algorithm defined in the paper "Quantum Addition Circuits and Unbounded Fan-Out" (https://arxiv.org/abs/0910.2530v1) that is
-        // based on a ripple-carry adder and requires no ancillary qubits. No input carry is supported and the carry for the n-th qubit is not calculcated.
-        // The sum of the two input operands 'a' and 'b' is stored in the qubits of operand 'b' (i.e. the right-hand side operand of the expression (a + b)).
-        // We will use N to denote the bitwidth of the operands in the description of the steps of the algorithm.
+        // TODO: Is result (a + b) mod 2^(bitwidth - 1)
+        // Implementation of the addition algorithm defined in the paper "Quantum Addition Circuits and Unbounded Fan-Out" (https://arxiv.org/abs/0910.2530v1)
+        // that is based on a ripple-carry adder and requires no ancillary qubits.  The sum of the two input operands 'a' and 'b' is stored in the qubits of
+        // operand 'b' (i.e. the right-hand side operand of the expression (a + b)). We will use N to denote the bitwidth of the operands in the description of the steps of the algorithm.
 
         // 1. Calculcate the terms (a_i XOR b_i) for all 0 < i < N and store results in b_i as CNOT(control: a_i, target: b_i)
         for (std::size_t i = 1; i < bitwidth && synthesisOk; ++i) {
             synthesisOk = annotatableQuantumComputation.addOperationsImplementingCnotGate(a[i], b[i]);
         }
+
+        // Optionally copy the value of the qubit a[N - 1] for the calculation of the carry out qubit
+        synthesisOk &= !optionalCarryOut.has_value() || annotatableQuantumComputation.addOperationsImplementingCnotGate(a[bitwidth - 1], *optionalCarryOut);
 
         // 2. For every N > i > 0 store a backup of a_(i - 1) into a_i as CNOT(control: a_(i - 1), target: a_i)
         for (std::size_t i = bitwidth - 1; i > 1 && synthesisOk; --i) {
@@ -814,6 +818,9 @@ namespace syrec {
         for (std::size_t i = 0; i < bitwidth - 1 && synthesisOk; ++i) {
             synthesisOk = annotatableQuantumComputation.addOperationsImplementingToffoliGate(b[i], a[i], a[i + 1]);
         }
+
+        // Optionally calculate the value of carry out qubit 
+        synthesisOk &= !optionalCarryOut.has_value() || annotatableQuantumComputation.addOperationsImplementingToffoliGate(a[bitwidth - 1], b[bitwidth - 1], *optionalCarryOut);
 
         // 4. Calculate term (b_i XOR c_i) of the final sum terms (a_i XOR b_i XOR c_i) and "remove" the carry bit values from the lines (a_(i - 1)) storing the backup values of a_i for all N > i > 0:
         //    - CNOT(control: a_i, b_i)
@@ -842,51 +849,6 @@ namespace syrec {
         synthesisOk &= increase(annotatableQuantumComputation, rhs, lhs);
         for (std::size_t i = 0; i < rhs.size() && synthesisOk; ++i) {
             synthesisOk = annotatableQuantumComputation.addOperationsImplementingNotGate(rhs[i]);
-        }
-        return synthesisOk;
-    }
-
-    bool SyrecSynthesis::increaseWithCarry(AnnotatableQuantumComputation& annotatableQuantumComputation, const std::vector<qc::Qubit>& dest, const std::vector<qc::Qubit>& src, qc::Qubit carry) {
-        auto bitwidth = static_cast<int>(src.size());
-        if (bitwidth == 0) {
-            return true;
-        }
-
-        if (src.size() != dest.size()) {
-            return false;
-        }
-
-        bool       synthesisOk      = true;
-        const auto unsignedBitwidth = static_cast<std::size_t>(bitwidth);
-        for (std::size_t i = 1U; i < unsignedBitwidth && synthesisOk; ++i) {
-            synthesisOk = annotatableQuantumComputation.addOperationsImplementingCnotGate(src.at(i), dest.at(i));
-        }
-
-        if (bitwidth > 1) {
-            synthesisOk &= annotatableQuantumComputation.addOperationsImplementingCnotGate(src.at(unsignedBitwidth - 1), carry);
-        }
-
-        for (int i = bitwidth - 2; i > 0 && synthesisOk; --i) {
-            const auto castedIndex = static_cast<std::size_t>(i);
-            synthesisOk            = annotatableQuantumComputation.addOperationsImplementingCnotGate(src.at(castedIndex), src.at(castedIndex + 1));
-        }
-
-        for (std::size_t i = 0U; i < unsignedBitwidth - 1 && synthesisOk; ++i) {
-            synthesisOk = annotatableQuantumComputation.addOperationsImplementingToffoliGate(src.at(i), dest.at(i), src.at(i + 1));
-        }
-        synthesisOk &= annotatableQuantumComputation.addOperationsImplementingToffoliGate(src.at(unsignedBitwidth - 1), dest.at(unsignedBitwidth - 1), carry);
-
-        for (int i = bitwidth - 1; i > 0 && synthesisOk; --i) {
-            const auto castedIndex = static_cast<std::size_t>(i);
-            synthesisOk            = annotatableQuantumComputation.addOperationsImplementingCnotGate(src.at(castedIndex), dest.at(castedIndex)) && annotatableQuantumComputation.addOperationsImplementingToffoliGate(dest.at(castedIndex - 1), src.at(castedIndex - 1), src.at(castedIndex));
-        }
-
-        for (std::size_t i = 1U; i < unsignedBitwidth - 1 && synthesisOk; ++i) {
-            synthesisOk = annotatableQuantumComputation.addOperationsImplementingCnotGate(src.at(i), src.at(i + 1));
-        }
-
-        for (std::size_t i = 0U; i < unsignedBitwidth && synthesisOk; ++i) {
-            synthesisOk = annotatableQuantumComputation.addOperationsImplementingCnotGate(src.at(i), dest.at(i));
         }
         return synthesisOk;
     }

--- a/test/configs/circuits_cost_aware_synthesis.json
+++ b/test/configs/circuits_cost_aware_synthesis.json
@@ -28,10 +28,10 @@
   },
 
   "bn_2": {
-    "num_gates": 194,
+    "num_gates": 192,
     "lines": 68,
-    "quantum_costs": 510,
-    "transistor_costs": 1776
+    "quantum_costs": 484,
+    "transistor_costs": 1728
   },
 
   "call_8": {
@@ -47,10 +47,10 @@
     "transistor_costs": 64
   },
   "divide_2": {
-    "num_gates": 252,
+    "num_gates": 246,
     "lines": 22,
-    "quantum_costs": 1076,
-    "transistor_costs": 2832
+    "quantum_costs": 998,
+    "transistor_costs": 2688
   },
 
   "for_4": {
@@ -110,10 +110,10 @@
   },
 
   "modulo_2": {
-    "num_gates": 31,
+    "num_gates": 30,
     "lines": 10,
-    "quantum_costs": 111,
-    "transistor_costs": 320
+    "quantum_costs": 98,
+    "transistor_costs": 296
   },
 
   "multiple_statement_4": {

--- a/test/configs/circuits_line_aware_synthesis.json
+++ b/test/configs/circuits_line_aware_synthesis.json
@@ -28,10 +28,10 @@
   },
 
   "bn_2": {
-    "num_gates": 278,
+    "num_gates": 276,
     "lines": 48,
-    "quantum_costs": 674,
-    "transistor_costs": 2256
+    "quantum_costs": 648,
+    "transistor_costs": 2208
   },
 
   "call_8": {
@@ -47,10 +47,10 @@
     "transistor_costs": 64
   },
   "divide_2": {
-    "num_gates": 252,
+    "num_gates": 246,
     "lines": 22,
-    "quantum_costs": 1076,
-    "transistor_costs": 2832
+    "quantum_costs": 998,
+    "transistor_costs": 2688
   },
   "for_4": {
     "num_gates": 208,
@@ -101,10 +101,10 @@
     "transistor_costs": 416
   },
   "modulo_2": {
-    "num_gates": 31,
+    "num_gates": 30,
     "lines": 10,
-    "quantum_costs": 111,
-    "transistor_costs": 320
+    "quantum_costs": 98,
+    "transistor_costs": 296
   },
   "multiple_statement_4": {
     "num_gates": 172,

--- a/test/unittests/simulation/test_synthesis_basic_operations.cpp
+++ b/test/unittests/simulation/test_synthesis_basic_operations.cpp
@@ -67,9 +67,8 @@ TYPED_TEST_P(BaseSimulationTestFixture, LogicalNegationOfNestedExpression) {
     };
 
     for (std::size_t i = 0; i < inputStatesToCheck.size(); ++i) {
-        constexpr std::size_t            inputStateSize = 5;
-        const syrec::NBitValuesContainer inputState(inputStateSize, inputStatesToCheck[i]);
-        const syrec::NBitValuesContainer expectedOutputState(inputStateSize, expectedOutputStates[i]);
+        const syrec::NBitValuesContainer inputState(this->annotatableQuantumComputation.getNqubits(), inputStatesToCheck[i]);
+        const syrec::NBitValuesContainer expectedOutputState(inputState.size(), expectedOutputStates[i]);
         ASSERT_NO_FATAL_FAILURE(this->assertSimulationResultForStateMatchesExpectedOne(inputState, expectedOutputState));
     }
 }
@@ -88,9 +87,8 @@ TYPED_TEST_P(BaseSimulationTestFixture, LogicalNegationOfUnaryExpression) {
     };
 
     for (std::size_t i = 0; i < inputStatesToCheck.size(); ++i) {
-        constexpr std::size_t            inputStateSize = 6;
-        const syrec::NBitValuesContainer inputState(inputStateSize, inputStatesToCheck[i]);
-        const syrec::NBitValuesContainer expectedOutputState(inputStateSize, expectedOutputStates[i]);
+        const syrec::NBitValuesContainer inputState(this->annotatableQuantumComputation.getNqubits(), inputStatesToCheck[i]);
+        const syrec::NBitValuesContainer expectedOutputState(inputState.size(), expectedOutputStates[i]);
         ASSERT_NO_FATAL_FAILURE(this->assertSimulationResultForStateMatchesExpectedOne(inputState, expectedOutputState));
     }
 }
@@ -123,9 +121,8 @@ TYPED_TEST_P(BaseSimulationTestFixture, LogicalNegationOfVariable) {
     };
 
     for (std::size_t i = 0; i < inputStatesToCheck.size(); ++i) {
-        constexpr std::size_t            inputStateSize = 4;
-        const syrec::NBitValuesContainer inputState(inputStateSize, inputStatesToCheck[i]);
-        const syrec::NBitValuesContainer expectedOutputState(inputStateSize, expectedOutputStates[i]);
+        const syrec::NBitValuesContainer inputState(this->annotatableQuantumComputation.getNqubits(), inputStatesToCheck[i]);
+        const syrec::NBitValuesContainer expectedOutputState(inputState.size(), expectedOutputStates[i]);
         ASSERT_NO_FATAL_FAILURE(this->assertSimulationResultForStateMatchesExpectedOne(inputState, expectedOutputState));
     }
 }
@@ -144,9 +141,8 @@ TYPED_TEST_P(BaseSimulationTestFixture, BitwiseNegationOfConstant) {
     };
 
     for (std::size_t i = 0; i < inputStatesToCheck.size(); ++i) {
-        constexpr std::size_t            inputStateSize = 4;
-        const syrec::NBitValuesContainer inputState(inputStateSize, inputStatesToCheck[i]);
-        const syrec::NBitValuesContainer expectedOutputState(inputStateSize, expectedOutputStates[i]);
+        const syrec::NBitValuesContainer inputState(this->annotatableQuantumComputation.getNqubits(), inputStatesToCheck[i]);
+        const syrec::NBitValuesContainer expectedOutputState(inputState.size(), expectedOutputStates[i]);
         ASSERT_NO_FATAL_FAILURE(this->assertSimulationResultForStateMatchesExpectedOne(inputState, expectedOutputState));
     }
 }
@@ -170,9 +166,8 @@ TYPED_TEST_P(BaseSimulationTestFixture, BitwiseNegationOfVariable) {
     };
 
     for (std::size_t i = 0; i < inputStatesToCheck.size(); ++i) {
-        constexpr std::size_t            inputStateSize = 6;
-        const syrec::NBitValuesContainer inputState(inputStateSize, inputStatesToCheck[i]);
-        const syrec::NBitValuesContainer expectedOutputState(inputStateSize, expectedOutputStates[i]);
+        const syrec::NBitValuesContainer inputState(this->annotatableQuantumComputation.getNqubits(), inputStatesToCheck[i]);
+        const syrec::NBitValuesContainer expectedOutputState(inputState.size(), expectedOutputStates[i]);
         ASSERT_NO_FATAL_FAILURE(this->assertSimulationResultForStateMatchesExpectedOne(inputState, expectedOutputState));
     }
 }
@@ -220,9 +215,8 @@ TYPED_TEST_P(BaseSimulationTestFixture, BitwiseNegationOfBinaryExpression) {
     };
 
     for (std::size_t i = 0; i < inputStatesToCheck.size(); ++i) {
-        constexpr std::size_t            inputStateSize = 10;
-        const syrec::NBitValuesContainer inputState(inputStateSize, inputStatesToCheck[i]);
-        const syrec::NBitValuesContainer expectedOutputState(inputStateSize, expectedOutputStates[i]);
+        const syrec::NBitValuesContainer inputState(this->annotatableQuantumComputation.getNqubits(), inputStatesToCheck[i]);
+        const syrec::NBitValuesContainer expectedOutputState(inputState.size(), expectedOutputStates[i]);
         ASSERT_NO_FATAL_FAILURE(this->assertSimulationResultForStateMatchesExpectedOne(inputState, expectedOutputState));
     }
 }
@@ -271,9 +265,8 @@ TYPED_TEST_P(BaseSimulationTestFixture, BitwiseNegationOfShiftExpression) {
     };
 
     for (std::size_t i = 0; i < inputStatesToCheck.size(); ++i) {
-        constexpr std::size_t            inputStateSize = 16;
-        const syrec::NBitValuesContainer inputState(inputStateSize, inputStatesToCheck[i]);
-        const syrec::NBitValuesContainer expectedOutputState(inputStateSize, expectedOutputStates[i]);
+        const syrec::NBitValuesContainer inputState(this->annotatableQuantumComputation.getNqubits(), inputStatesToCheck[i]);
+        const syrec::NBitValuesContainer expectedOutputState(inputState.size(), expectedOutputStates[i]);
         ASSERT_NO_FATAL_FAILURE(this->assertSimulationResultForStateMatchesExpectedOne(inputState, expectedOutputState));
     }
 }
@@ -292,14 +285,14 @@ TYPED_TEST_P(BaseSimulationTestFixture, BitwiseNegationOfUnaryExpression) {
     };
 
     for (std::size_t i = 0; i < inputStatesToCheck.size(); ++i) {
-        constexpr std::size_t            inputStateSize = 6;
-        const syrec::NBitValuesContainer inputState(inputStateSize, inputStatesToCheck[i]);
-        const syrec::NBitValuesContainer expectedOutputState(inputStateSize, expectedOutputStates[i]);
+        const syrec::NBitValuesContainer inputState(this->annotatableQuantumComputation.getNqubits(), inputStatesToCheck[i]);
+        const syrec::NBitValuesContainer expectedOutputState(inputState.size(), expectedOutputStates[i]);
         ASSERT_NO_FATAL_FAILURE(this->assertSimulationResultForStateMatchesExpectedOne(inputState, expectedOutputState));
     }
 }
 
-TYPED_TEST_P(BaseSimulationTestFixture, FourBitAddition) {
+// TODO: Should error cases in synthesis be checked (that should already be handled by the parser)?
+TYPED_TEST_P(BaseSimulationTestFixture, AddAssignWithRightHandSideEqualToVariable) {
     syrec::Program program;
     ASSERT_NO_FATAL_FAILURE(parseSyrecProgram("module main(inout a(4), in b(4)) a += b", program));
     ASSERT_TRUE(this->performProgramSynthesis(program));
@@ -343,7 +336,989 @@ TYPED_TEST_P(BaseSimulationTestFixture, FourBitAddition) {
     };
 
     for (std::size_t i = 0; i < inputStatesToCheck.size(); ++i) {
-        constexpr std::size_t            inputStateSize = 8;
+        const syrec::NBitValuesContainer inputState(this->annotatableQuantumComputation.getNqubits(), inputStatesToCheck[i]);
+        const syrec::NBitValuesContainer expectedOutputState(inputState.size(), expectedOutputStates[i]);
+        ASSERT_NO_FATAL_FAILURE(this->assertSimulationResultForStateMatchesExpectedOne(inputState, expectedOutputState));
+    }
+}
+
+TYPED_TEST_P(BaseSimulationTestFixture, AddAssignWithRightHandSideEqualToConstant) {
+    syrec::Program program;
+    ASSERT_NO_FATAL_FAILURE(parseSyrecProgram("module main(inout a(3)) a += 2", program));
+    ASSERT_TRUE(this->performProgramSynthesis(program));
+
+    const std::vector<std::uint64_t> inputStatesToCheck = {
+            0, // 000XX
+            1, // 100XX
+            2, // 010XX
+            3, // 110XX
+            4, // 001XX
+            5, // 101XX
+            6, // 011XX
+            7, // 111XX
+    };
+    const std::vector<std::uint64_t> expectedOutputStates = {
+            2, // 010XX
+            3, // 110XX
+            4, // 001XX
+            5, // 101XX
+            6, // 011XX
+            7, // 111XX
+            0, // 000XX
+            1, // 100XX
+    };
+
+    for (std::size_t i = 0; i < inputStatesToCheck.size(); ++i) {
+        const syrec::NBitValuesContainer inputState(this->annotatableQuantumComputation.getNqubits(), inputStatesToCheck[i]);
+        const syrec::NBitValuesContainer expectedOutputState(inputState.size(), expectedOutputStates[i]);
+        ASSERT_NO_FATAL_FAILURE(this->assertSimulationResultForStateMatchesExpectedOne(inputState, expectedOutputState));
+    }
+}
+
+TYPED_TEST_P(BaseSimulationTestFixture, AddAssignWithRightHandSideEqualToBinaryExpression) {
+    syrec::Program program;
+    ASSERT_NO_FATAL_FAILURE(parseSyrecProgram("module main(inout a(2), in b(2)) a += (b + 1)", program));
+    ASSERT_TRUE(this->performProgramSynthesis(program));
+
+    const std::vector<std::uint64_t> inputStatesToCheck = {
+            0,  // 0000XXXX
+            1,  // 1000XXXX
+            2,  // 0100XXXX
+            3,  // 1100XXXX
+            4,  // 0010XXXX
+            5,  // 1010XXXX
+            6,  // 0110XXXX
+            7,  // 1110XXXX
+            8,  // 0001XXXX
+            9,  // 1001XXXX
+            10, // 0101XXXX
+            11, // 1101XXXX
+            12, // 0011XXXX
+            13, // 1011XXXX
+            14, // 0111XXXX
+            15, // 1111XXXX
+    };
+    const std::vector<std::uint64_t> expectedOutputStates = {
+            1,  // 1000XXXX
+            2,  // 0100XXXX
+            3,  // 1100XXXX
+            0,  // 0000XXXX
+            6,  // 0110XXXX
+            7,  // 1110XXXX
+            4,  // 0010XXXX
+            5,  // 1010XXXX
+            11, // 1101XXXX
+            8,  // 0001XXXX
+            9,  // 1001XXXX
+            10, // 0101XXXX
+            12, // 0011XXXX
+            13, // 1011XXXX
+            14, // 0111XXXX
+            15, // 1111XXXX
+    };
+
+    for (std::size_t i = 0; i < inputStatesToCheck.size(); ++i) {
+        const syrec::NBitValuesContainer inputState(this->annotatableQuantumComputation.getNqubits(), inputStatesToCheck[i]);
+        const syrec::NBitValuesContainer expectedOutputState(inputState.size(), expectedOutputStates[i]);
+        ASSERT_NO_FATAL_FAILURE(this->assertSimulationResultForStateMatchesExpectedOne(inputState, expectedOutputState));
+    }
+}
+
+TYPED_TEST_P(BaseSimulationTestFixture, AddAssignWithRightHandSideEqualToShiftExpression) {
+    syrec::Program program;
+    ASSERT_NO_FATAL_FAILURE(parseSyrecProgram("module main(inout a(2), in b(2)) a += (b << 1)", program));
+    ASSERT_TRUE(this->performProgramSynthesis(program));
+
+    const std::vector<std::uint64_t> inputStatesToCheck = {
+            0,  // 0000
+            1,  // 1000
+            2,  // 0100
+            3,  // 1100
+            4,  // 0010
+            5,  // 1010
+            6,  // 0110
+            7,  // 1110
+            8,  // 0001
+            9,  // 1001
+            10, // 0101
+            11, // 1101
+            12, // 0011
+            13, // 1011
+            14, // 0111
+            15, // 1111
+    };
+    const std::vector<std::uint64_t> expectedOutputStates = {
+            0,  // 0000
+            1,  // 1000
+            2,  // 0100
+            3,  // 1100
+            6,  // 0110
+            7,  // 1110
+            4,  // 0010
+            5,  // 1010
+            8,  // 0001
+            9,  // 1001
+            10, // 0101
+            11, // 1101
+            14, // 0111
+            15, // 1111
+            12, // 0011
+            13, // 1011
+    };
+
+    for (std::size_t i = 0; i < inputStatesToCheck.size(); ++i) {
+        const syrec::NBitValuesContainer inputState(this->annotatableQuantumComputation.getNqubits(), inputStatesToCheck[i]);
+        const syrec::NBitValuesContainer expectedOutputState(inputState.size(), expectedOutputStates[i]);
+        ASSERT_NO_FATAL_FAILURE(this->assertSimulationResultForStateMatchesExpectedOne(inputState, expectedOutputState));
+    }
+}
+
+TYPED_TEST_P(BaseSimulationTestFixture, AddAssignWithRightHandSideEqualToUnaryExpression) {
+    syrec::Program program;
+    ASSERT_NO_FATAL_FAILURE(parseSyrecProgram("module main(inout a(2), in b(2)) a.1 += !(b.0 != b.1)", program));
+    ASSERT_TRUE(this->performProgramSynthesis(program));
+
+    const std::vector<std::uint64_t> inputStatesToCheck = {
+            0,  // 0000
+            1,  // 1000
+            2,  // 0100
+            3,  // 1100
+            4,  // 0010
+            5,  // 1010
+            6,  // 0110
+            7,  // 1110
+            8,  // 0001
+            9,  // 1001
+            10, // 0101
+            11, // 1101
+            12, // 0011
+            13, // 1011
+            14, // 0111
+            15, // 1111
+    };
+    const std::vector<std::uint64_t> expectedOutputStates = {
+            2,  // 0100
+            3,  // 1100
+            0,  // 0000
+            1,  // 1000
+            4,  // 0010
+            5,  // 1010
+            6,  // 0110
+            7,  // 1110
+            8,  // 0001
+            9,  // 1001
+            10, // 0101
+            11, // 1101
+            14, // 0111
+            15, // 1111
+            12, // 0011
+            13, // 1011
+    };
+
+    for (std::size_t i = 0; i < inputStatesToCheck.size(); ++i) {
+        const syrec::NBitValuesContainer inputState(this->annotatableQuantumComputation.getNqubits(), inputStatesToCheck[i]);
+        const syrec::NBitValuesContainer expectedOutputState(inputState.size(), expectedOutputStates[i]);
+        ASSERT_NO_FATAL_FAILURE(this->assertSimulationResultForStateMatchesExpectedOne(inputState, expectedOutputState));
+    }
+}
+
+TYPED_TEST_P(BaseSimulationTestFixture, AddAssignWithRightHandSideEqualToNestedExpression) {
+    syrec::Program program;
+    ASSERT_NO_FATAL_FAILURE(parseSyrecProgram("module main(inout a(2), in b(2)) a.1 += ((b > 0) && (b < 3))", program));
+    ASSERT_TRUE(this->performProgramSynthesis(program));
+
+    const std::vector<std::uint64_t> inputStatesToCheck = {
+            0,  // 0000
+            1,  // 1000
+            2,  // 0100
+            3,  // 1100
+            4,  // 0010
+            5,  // 1010
+            6,  // 0110
+            7,  // 1110
+            8,  // 0001
+            9,  // 1001
+            10, // 0101
+            11, // 1101
+            12, // 0011
+            13, // 1011
+            14, // 0111
+            15, // 1111
+    };
+    const std::vector<std::uint64_t> expectedOutputStates = {
+            0,  // 0000
+            1,  // 1000
+            2,  // 0100
+            3,  // 1100
+            6,  // 0110
+            7,  // 1110
+            4,  // 0010
+            5,  // 1010
+            10, // 0101
+            11, // 1101
+            8,  // 0001
+            9,  // 1001
+            12, // 0011
+            13, // 1011
+            14, // 0111
+            15, // 1111
+    };
+
+    for (std::size_t i = 0; i < inputStatesToCheck.size(); ++i) {
+        const syrec::NBitValuesContainer inputState(this->annotatableQuantumComputation.getNqubits(), inputStatesToCheck[i]);
+        const syrec::NBitValuesContainer expectedOutputState(inputState.size(), expectedOutputStates[i]);
+        ASSERT_NO_FATAL_FAILURE(this->assertSimulationResultForStateMatchesExpectedOne(inputState, expectedOutputState));
+    }
+}
+
+TYPED_TEST_P(BaseSimulationTestFixture, AddAssignOfBitOfVariable) {
+    syrec::Program program;
+    ASSERT_NO_FATAL_FAILURE(parseSyrecProgram("module main(inout a(3)) a.1 += 1", program));
+    ASSERT_TRUE(this->performProgramSynthesis(program));
+
+    const std::vector<std::uint64_t> inputStatesToCheck = {
+            0, // 000
+            1, // 100
+            2, // 010
+            3, // 110
+            4, // 001
+            5, // 101
+            6, // 011
+            7, // 111
+    };
+    const std::vector<std::uint64_t> expectedOutputStates = {
+            2, // 010
+            3, // 110
+            0, // 000
+            1, // 100
+            6, // 011
+            7, // 111
+            4, // 001
+            5, // 101
+    };
+
+    for (std::size_t i = 0; i < inputStatesToCheck.size(); ++i) {
+        const syrec::NBitValuesContainer inputState(this->annotatableQuantumComputation.getNqubits(), inputStatesToCheck[i]);
+        const syrec::NBitValuesContainer expectedOutputState(inputState.size(), expectedOutputStates[i]);
+        ASSERT_NO_FATAL_FAILURE(this->assertSimulationResultForStateMatchesExpectedOne(inputState, expectedOutputState));
+    }
+}
+
+TYPED_TEST_P(BaseSimulationTestFixture, AddAssignOfBitrangeOfVariableWithStartLargerThanEnd) {
+    syrec::Program program;
+    ASSERT_NO_FATAL_FAILURE(parseSyrecProgram("module main(inout a(3)) a.2:1 += 1", program));
+    ASSERT_TRUE(this->performProgramSynthesis(program));
+
+    const std::vector<std::uint64_t> inputStatesToCheck = {
+            0, // 000
+            1, // 100
+            2, // 010
+            3, // 110
+            4, // 001
+            5, // 101
+            6, // 011
+            7, // 111
+    };
+    const std::vector<std::uint64_t> expectedOutputStates = {
+            4, // 001
+            5, // 101
+            6, // 011
+            7, // 111
+            2, // 010
+            3, // 110
+            0, // 000
+            1, // 100
+    };
+
+    for (std::size_t i = 0; i < inputStatesToCheck.size(); ++i) {
+        const syrec::NBitValuesContainer inputState(this->annotatableQuantumComputation.getNqubits(), inputStatesToCheck[i]);
+        const syrec::NBitValuesContainer expectedOutputState(inputState.size(), expectedOutputStates[i]);
+        ASSERT_NO_FATAL_FAILURE(this->assertSimulationResultForStateMatchesExpectedOne(inputState, expectedOutputState));
+    }
+}
+
+TYPED_TEST_P(BaseSimulationTestFixture, AddAssignOfBitrangeOfVariableWithStartSmallerThanEnd) {
+    syrec::Program program;
+    ASSERT_NO_FATAL_FAILURE(parseSyrecProgram("module main(inout a(3)) a.1:2 += 1", program));
+    ASSERT_TRUE(this->performProgramSynthesis(program));
+
+    const std::vector<std::uint64_t> inputStatesToCheck = {
+            0, // 000
+            1, // 100
+            2, // 010
+            3, // 110
+            4, // 001
+            5, // 101
+            6, // 011
+            7, // 111
+    };
+    const std::vector<std::uint64_t> expectedOutputStates = {
+            2, // 010
+            3, // 110
+            4, // 001
+            5, // 101
+            6, // 011
+            7, // 111
+            0, // 000
+            1, // 100
+    };
+
+    for (std::size_t i = 0; i < inputStatesToCheck.size(); ++i) {
+        const syrec::NBitValuesContainer inputState(this->annotatableQuantumComputation.getNqubits(), inputStatesToCheck[i]);
+        const syrec::NBitValuesContainer expectedOutputState(inputState.size(), expectedOutputStates[i]);
+        ASSERT_NO_FATAL_FAILURE(this->assertSimulationResultForStateMatchesExpectedOne(inputState, expectedOutputState));
+    }
+}
+
+TYPED_TEST_P(BaseSimulationTestFixture, AddAssignOfValueOfDimensionOfVariable) {
+    syrec::Program program;
+    ASSERT_NO_FATAL_FAILURE(parseSyrecProgram("module main(inout a[2](2)) a[1] += 2", program));
+    ASSERT_TRUE(this->performProgramSynthesis(program));
+
+    const std::vector<std::uint64_t> inputStatesToCheck = {
+            0,  // 0000
+            1,  // 1000
+            2,  // 0100
+            3,  // 1100
+            4,  // 0010
+            5,  // 1010
+            6,  // 0110
+            7,  // 1110
+            8,  // 0001
+            9,  // 1001
+            10, // 0101
+            11, // 1101
+            12, // 0011
+            13, // 1011
+            14, // 0111
+            15, // 1111
+    };
+    const std::vector<std::uint64_t> expectedOutputStates = {
+            8,  // 0001
+            9,  // 1001
+            10, // 0101
+            11, // 1101
+            12, // 0011
+            13, // 1011
+            14, // 0111
+            15, // 1111
+            0,  // 0000
+            1,  // 1000
+            2,  // 0100
+            3,  // 1100
+            4,  // 0010
+            5,  // 1010
+            6,  // 0110
+            7,  // 1110
+    };
+
+    for (std::size_t i = 0; i < inputStatesToCheck.size(); ++i) {
+        const syrec::NBitValuesContainer inputState(this->annotatableQuantumComputation.getNqubits(), inputStatesToCheck[i]);
+        const syrec::NBitValuesContainer expectedOutputState(inputState.size(), expectedOutputStates[i]);
+        ASSERT_NO_FATAL_FAILURE(this->assertSimulationResultForStateMatchesExpectedOne(inputState, expectedOutputState));
+    }
+}
+
+TYPED_TEST_P(BaseSimulationTestFixture, AddAssignOfBitOfValueOfDimensionOfVariable) {
+    syrec::Program program;
+    ASSERT_NO_FATAL_FAILURE(parseSyrecProgram("module main(inout a[2](2)) a[1].1 += 1", program));
+    ASSERT_TRUE(this->performProgramSynthesis(program));
+
+    const std::vector<std::uint64_t> inputStatesToCheck = {
+            0,  // 0000
+            1,  // 1000
+            2,  // 0100
+            3,  // 1100
+            4,  // 0010
+            5,  // 1010
+            6,  // 0110
+            7,  // 1110
+            8,  // 0001
+            9,  // 1001
+            10, // 0101
+            11, // 1101
+            12, // 0011
+            13, // 1011
+            14, // 0111
+            15, // 1111
+    };
+    const std::vector<std::uint64_t> expectedOutputStates = {
+            8,  // 0001
+            9,  // 1001
+            10, // 0101
+            11, // 1101
+            12, // 0011
+            13, // 1011
+            14, // 0111
+            15, // 1111
+            0,  // 0000
+            1,  // 1000
+            2,  // 0100
+            3,  // 1100
+            4,  // 0010
+            5,  // 1010
+            6,  // 0110
+            7,  // 1110
+    };
+
+    for (std::size_t i = 0; i < inputStatesToCheck.size(); ++i) {
+        const syrec::NBitValuesContainer inputState(this->annotatableQuantumComputation.getNqubits(), inputStatesToCheck[i]);
+        const syrec::NBitValuesContainer expectedOutputState(inputState.size(), expectedOutputStates[i]);
+        ASSERT_NO_FATAL_FAILURE(this->assertSimulationResultForStateMatchesExpectedOne(inputState, expectedOutputState));
+    }
+}
+
+TYPED_TEST_P(BaseSimulationTestFixture, AddAssignOfBitrangeOfValueOfDimensionOfVariableWithStartSmallerThanEnd) {
+    syrec::Program program;
+    ASSERT_NO_FATAL_FAILURE(parseSyrecProgram("module main(inout a[2](2)) a[1].0:1 += 3", program));
+    ASSERT_TRUE(this->performProgramSynthesis(program));
+
+    const std::vector<std::uint64_t> inputStatesToCheck = {
+            0,  // 0000
+            1,  // 1000
+            2,  // 0100
+            3,  // 1100
+            4,  // 0010
+            5,  // 1010
+            6,  // 0110
+            7,  // 1110
+            8,  // 0001
+            9,  // 1001
+            10, // 0101
+            11, // 1101
+            12, // 0011
+            13, // 1011
+            14, // 0111
+            15, // 1111
+    };
+    const std::vector<std::uint64_t> expectedOutputStates = {
+            12, // 0011
+            13, // 1011
+            14, // 0111
+            15, // 1111
+            0,  // 0000
+            1,  // 1000
+            2,  // 0100
+            3,  // 1100
+            4,  // 0010
+            5,  // 1010
+            6,  // 0110
+            7,  // 1110
+            8,  // 0001
+            9,  // 1001
+            10, // 0101
+            11, // 1101
+    };
+
+    for (std::size_t i = 0; i < inputStatesToCheck.size(); ++i) {
+        const syrec::NBitValuesContainer inputState(this->annotatableQuantumComputation.getNqubits(), inputStatesToCheck[i]);
+        const syrec::NBitValuesContainer expectedOutputState(inputState.size(), expectedOutputStates[i]);
+        ASSERT_NO_FATAL_FAILURE(this->assertSimulationResultForStateMatchesExpectedOne(inputState, expectedOutputState));
+    }
+}
+
+TYPED_TEST_P(BaseSimulationTestFixture, AddAssignOfBitrangeOfValueOfDimensionOfVariableWithStartLargerThanEnd) {
+    syrec::Program program;
+    ASSERT_NO_FATAL_FAILURE(parseSyrecProgram("module main(inout a[2](2)) a[1].1:0 += 3", program));
+    ASSERT_TRUE(this->performProgramSynthesis(program));
+
+    const std::vector<std::uint64_t> inputStatesToCheck = {
+            0,  // 0000
+            1,  // 1000
+            2,  // 0100
+            3,  // 1100
+            4,  // 0010
+            5,  // 1010
+            6,  // 0110
+            7,  // 1110
+            8,  // 0001
+            9,  // 1001
+            10, // 0101
+            11, // 1101
+            12, // 0011
+            13, // 1011
+            14, // 0111
+            15, // 1111
+    };
+    const std::vector<std::uint64_t> expectedOutputStates = {
+            12, // 0011
+            13, // 1011
+            14, // 0111
+            15, // 1111
+            8,  // 0001
+            9,  // 1001
+            10, // 0101
+            11, // 1101
+            0,  // 0000
+            1,  // 1000
+            2,  // 0100
+            3,  // 1100
+            4,  // 0010
+            5,  // 1010
+            6,  // 0110
+            7,  // 1110
+    };
+
+    for (std::size_t i = 0; i < inputStatesToCheck.size(); ++i) {
+        const syrec::NBitValuesContainer inputState(this->annotatableQuantumComputation.getNqubits(), inputStatesToCheck[i]);
+        const syrec::NBitValuesContainer expectedOutputState(inputState.size(), expectedOutputStates[i]);
+        ASSERT_NO_FATAL_FAILURE(this->assertSimulationResultForStateMatchesExpectedOne(inputState, expectedOutputState));
+    }
+}
+
+TYPED_TEST_P(BaseSimulationTestFixture, AddAssignOfBitrangeOfValueOfDimensionOfVariableWithStartEqualToEnd) {
+    syrec::Program program;
+    ASSERT_NO_FATAL_FAILURE(parseSyrecProgram("module main(inout a[2](2)) a[0].1:1 += 1", program));
+    ASSERT_TRUE(this->performProgramSynthesis(program));
+
+    const std::vector<std::uint64_t> inputStatesToCheck = {
+            0,  // 0000
+            1,  // 1000
+            2,  // 0100
+            3,  // 1100
+            4,  // 0010
+            5,  // 1010
+            6,  // 0110
+            7,  // 1110
+            8,  // 0001
+            9,  // 1001
+            10, // 0101
+            11, // 1101
+            12, // 0011
+            13, // 1011
+            14, // 0111
+            15, // 1111
+    };
+    const std::vector<std::uint64_t> expectedOutputStates = {
+            2,  // 0100
+            3,  // 1100
+            0,  // 0000
+            1,  // 1000
+            6,  // 0110
+            7,  // 1110
+            4,  // 0010
+            5,  // 1010
+            10, // 0101
+            11, // 1101
+            8,  // 0001
+            9,  // 1001
+            14, // 0111
+            15, // 1111
+            12, // 0011
+            13, // 1011
+    };
+
+    for (std::size_t i = 0; i < inputStatesToCheck.size(); ++i) {
+        const syrec::NBitValuesContainer inputState(this->annotatableQuantumComputation.getNqubits(), inputStatesToCheck[i]);
+        const syrec::NBitValuesContainer expectedOutputState(inputState.size(), expectedOutputStates[i]);
+        ASSERT_NO_FATAL_FAILURE(this->assertSimulationResultForStateMatchesExpectedOne(inputState, expectedOutputState));
+    }
+}
+
+TYPED_TEST_P(BaseSimulationTestFixture, IncrementAssignOfVariable) {
+    syrec::Program program;
+    ASSERT_NO_FATAL_FAILURE(parseSyrecProgram("module main(inout a(3)) ++= a", program));
+    ASSERT_TRUE(this->performProgramSynthesis(program));
+
+    const std::vector<std::uint64_t> inputStatesToCheck = {
+            0, // 000
+            1, // 100
+            2, // 010
+            3, // 110
+            4, // 001
+            5, // 101
+            6, // 011
+            7, // 111
+    };
+    const std::vector<std::uint64_t> expectedOutputStates = {
+            1, // 100
+            2, // 010
+            3, // 110
+            4, // 001
+            5, // 101
+            6, // 011
+            7, // 111
+            0, // 000
+    };
+
+    for (std::size_t i = 0; i < inputStatesToCheck.size(); ++i) {
+        const syrec::NBitValuesContainer inputState(this->annotatableQuantumComputation.getNqubits(), inputStatesToCheck[i]);
+        const syrec::NBitValuesContainer expectedOutputState(inputState.size(), expectedOutputStates[i]);
+        ASSERT_NO_FATAL_FAILURE(this->assertSimulationResultForStateMatchesExpectedOne(inputState, expectedOutputState));
+    }
+}
+
+TYPED_TEST_P(BaseSimulationTestFixture, IncrementAssignOfBitOfVariable) {
+    syrec::Program program;
+    ASSERT_NO_FATAL_FAILURE(parseSyrecProgram("module main(inout a(3)) ++= a.1", program));
+    ASSERT_TRUE(this->performProgramSynthesis(program));
+
+    const std::vector<std::uint64_t> inputStatesToCheck = {
+            0, // 000
+            1, // 100
+            2, // 010
+            3, // 110
+            4, // 001
+            5, // 101
+            6, // 011
+            7, // 111
+    };
+    const std::vector<std::uint64_t> expectedOutputStates = {
+            2, // 010
+            3, // 110
+            0, // 000
+            1, // 100
+            6, // 011
+            7, // 111
+            4, // 001
+            5, // 101
+    };
+
+    for (std::size_t i = 0; i < inputStatesToCheck.size(); ++i) {
+        const syrec::NBitValuesContainer inputState(this->annotatableQuantumComputation.getNqubits(), inputStatesToCheck[i]);
+        const syrec::NBitValuesContainer expectedOutputState(inputState.size(), expectedOutputStates[i]);
+        ASSERT_NO_FATAL_FAILURE(this->assertSimulationResultForStateMatchesExpectedOne(inputState, expectedOutputState));
+    }
+}
+
+TYPED_TEST_P(BaseSimulationTestFixture, IncrementAssignOfBitrangeOfVariableWithBitrangeStartLargerThanEnd) {
+    syrec::Program program;
+    ASSERT_NO_FATAL_FAILURE(parseSyrecProgram("module main(inout a(4)) ++= a.2:1", program));
+    ASSERT_TRUE(this->performProgramSynthesis(program));
+
+    const std::vector<std::uint64_t> inputStatesToCheck = {
+            0,  // 0000
+            1,  // 1000
+            2,  // 0100
+            3,  // 1100
+            4,  // 0010
+            5,  // 1010
+            6,  // 0110
+            7,  // 1110
+            8,  // 0001
+            9,  // 1001
+            10, // 0101
+            11, // 1101
+            12, // 0011
+            13, // 1011
+            14, // 0111
+            15, // 1111
+    };
+    const std::vector<std::uint64_t> expectedOutputStates = {
+            4,  // 0010
+            5,  // 1010
+            6,  // 0110
+            7,  // 1110
+            2,  // 0100
+            3,  // 1100
+            0,  // 0000
+            1,  // 1000
+            12, // 0011
+            13, // 1011
+            14, // 0111
+            15, // 1111
+            10, // 0101
+            11, // 1101
+            8,  // 0001
+            9,  // 1001
+    };
+
+    for (std::size_t i = 0; i < inputStatesToCheck.size(); ++i) {
+        const syrec::NBitValuesContainer inputState(this->annotatableQuantumComputation.getNqubits(), inputStatesToCheck[i]);
+        const syrec::NBitValuesContainer expectedOutputState(inputState.size(), expectedOutputStates[i]);
+        ASSERT_NO_FATAL_FAILURE(this->assertSimulationResultForStateMatchesExpectedOne(inputState, expectedOutputState));
+    }
+}
+
+TYPED_TEST_P(BaseSimulationTestFixture, IncrementAssignOfBitrangeOfVariableWithBitrangeStartSmallerThanEnd) {
+    syrec::Program program;
+    ASSERT_NO_FATAL_FAILURE(parseSyrecProgram("module main(inout a(4)) ++= a.1:2", program));
+    ASSERT_TRUE(this->performProgramSynthesis(program));
+
+    const std::vector<std::uint64_t> inputStatesToCheck = {
+            0,  // 0000
+            1,  // 1000
+            2,  // 0100
+            3,  // 1100
+            4,  // 0010
+            5,  // 1010
+            6,  // 0110
+            7,  // 1110
+            8,  // 0001
+            9,  // 1001
+            10, // 0101
+            11, // 1101
+            12, // 0011
+            13, // 1011
+            14, // 0111
+            15, // 1111
+    };
+    const std::vector<std::uint64_t> expectedOutputStates = {
+            2,  // 0100
+            3,  // 1100
+            4,  // 0010
+            5,  // 1010
+            6,  // 0110
+            7,  // 1110
+            0,  // 0000
+            1,  // 1000
+            10, // 0101
+            11, // 1101
+            12, // 0011
+            13, // 1011
+            14, // 0111
+            15, // 1111
+            8,  // 0001
+            9,  // 1001
+    };
+
+    for (std::size_t i = 0; i < inputStatesToCheck.size(); ++i) {
+        const syrec::NBitValuesContainer inputState(this->annotatableQuantumComputation.getNqubits(), inputStatesToCheck[i]);
+        const syrec::NBitValuesContainer expectedOutputState(inputState.size(), expectedOutputStates[i]);
+        ASSERT_NO_FATAL_FAILURE(this->assertSimulationResultForStateMatchesExpectedOne(inputState, expectedOutputState));
+    }
+}
+
+TYPED_TEST_P(BaseSimulationTestFixture, IncrementValueOfDimensionOfVariable) {
+    syrec::Program program;
+    ASSERT_NO_FATAL_FAILURE(parseSyrecProgram("module main(inout a[2](2)) ++= a[1]", program));
+    ASSERT_TRUE(this->performProgramSynthesis(program));
+
+    const std::vector<std::uint64_t> inputStatesToCheck = {
+            0,  // 0000
+            1,  // 1000
+            2,  // 0100
+            3,  // 1100
+            4,  // 0010
+            5,  // 1010
+            6,  // 0110
+            7,  // 1110
+            8,  // 0001
+            9,  // 1001
+            10, // 0101
+            11, // 1101
+            12, // 0011
+            13, // 1011
+            14, // 0111
+            15, // 1111
+    };
+    const std::vector<std::uint64_t> expectedOutputStates = {
+            4,  // 0010
+            5,  // 1010
+            6,  // 0110
+            7,  // 1110
+            8,  // 0001
+            9,  // 1001
+            10, // 0101
+            11, // 1101
+            12, // 0011
+            13, // 1011
+            14, // 0111
+            15, // 1111
+            0,  // 0000
+            1,  // 1000
+            2,  // 0100
+            3,  // 1100
+    };
+
+    for (std::size_t i = 0; i < inputStatesToCheck.size(); ++i) {
+        const syrec::NBitValuesContainer inputState(this->annotatableQuantumComputation.getNqubits(), inputStatesToCheck[i]);
+        const syrec::NBitValuesContainer expectedOutputState(inputState.size(), expectedOutputStates[i]);
+        ASSERT_NO_FATAL_FAILURE(this->assertSimulationResultForStateMatchesExpectedOne(inputState, expectedOutputState));
+    }
+}
+
+TYPED_TEST_P(BaseSimulationTestFixture, IncrementBitOfValueOfDimensionOfVariable) {
+    syrec::Program program;
+    ASSERT_NO_FATAL_FAILURE(parseSyrecProgram("module main(inout a[2](2)) ++= a[0].1", program));
+    ASSERT_TRUE(this->performProgramSynthesis(program));
+
+    const std::vector<std::uint64_t> inputStatesToCheck = {
+            0,  // 0000
+            1,  // 1000
+            2,  // 0100
+            3,  // 1100
+            4,  // 0010
+            5,  // 1010
+            6,  // 0110
+            7,  // 1110
+            8,  // 0001
+            9,  // 1001
+            10, // 0101
+            11, // 1101
+            12, // 0011
+            13, // 1011
+            14, // 0111
+            15, // 1111
+    };
+    const std::vector<std::uint64_t> expectedOutputStates = {
+            2,  // 0100
+            3,  // 1100
+            0,  // 0000
+            1,  // 1000
+            6,  // 0110
+            7,  // 1110
+            4,  // 0010
+            5,  // 1010
+            10, // 0101
+            11, // 1101
+            8,  // 0001
+            9,  // 1001
+            14, // 0111
+            15, // 1111
+            12, // 0011
+            13, // 1011
+    };
+
+    for (std::size_t i = 0; i < inputStatesToCheck.size(); ++i) {
+        const syrec::NBitValuesContainer inputState(this->annotatableQuantumComputation.getNqubits(), inputStatesToCheck[i]);
+        const syrec::NBitValuesContainer expectedOutputState(inputState.size(), expectedOutputStates[i]);
+        ASSERT_NO_FATAL_FAILURE(this->assertSimulationResultForStateMatchesExpectedOne(inputState, expectedOutputState));
+    }
+}
+
+TYPED_TEST_P(BaseSimulationTestFixture, IncrementBitrangeOfValueOfDimensionOfVariableWithBitrangeStartLargerThanEnd) {
+    syrec::Program program;
+    ASSERT_NO_FATAL_FAILURE(parseSyrecProgram("module main(inout a[2](2)) ++= a[1].1:0", program));
+    ASSERT_TRUE(this->performProgramSynthesis(program));
+
+    const std::vector<std::uint64_t> inputStatesToCheck = {
+            0,  // 0000
+            1,  // 1000
+            2,  // 0100
+            3,  // 1100
+            4,  // 0010
+            5,  // 1010
+            6,  // 0110
+            7,  // 1110
+            8,  // 0001
+            9,  // 1001
+            10, // 0101
+            11, // 1101
+            12, // 0011
+            13, // 1011
+            14, // 0111
+            15, // 1111
+    };
+    const std::vector<std::uint64_t> expectedOutputStates = {
+            8,  // 0001
+            9,  // 1001
+            10, // 0101
+            11, // 1101
+            12, // 0011
+            13, // 1011
+            14, // 0111
+            15, // 1111
+            4,  // 0010
+            5,  // 1010
+            6,  // 0110
+            7,  // 1110
+            0,  // 0000
+            1,  // 1000
+            2,  // 0100
+            3,  // 1100
+    };
+
+    for (std::size_t i = 0; i < inputStatesToCheck.size(); ++i) {
+        const syrec::NBitValuesContainer inputState(this->annotatableQuantumComputation.getNqubits(), inputStatesToCheck[i]);
+        const syrec::NBitValuesContainer expectedOutputState(inputState.size(), expectedOutputStates[i]);
+        ASSERT_NO_FATAL_FAILURE(this->assertSimulationResultForStateMatchesExpectedOne(inputState, expectedOutputState));
+    }
+}
+
+TYPED_TEST_P(BaseSimulationTestFixture, IncrementBitrangeOfValueOfDimensionOfVariableWithBitrangeStartSmallerThanEnd) {
+    syrec::Program program;
+    ASSERT_NO_FATAL_FAILURE(parseSyrecProgram("module main(inout a[2](2)) ++= a[0].0:1", program));
+    ASSERT_TRUE(this->performProgramSynthesis(program));
+
+    const std::vector<std::uint64_t> inputStatesToCheck = {
+            0,  // 0000
+            1,  // 1000
+            2,  // 0100
+            3,  // 1100
+            4,  // 0010
+            5,  // 1010
+            6,  // 0110
+            7,  // 1110
+            8,  // 0001
+            9,  // 1001
+            10, // 0101
+            11, // 1101
+            12, // 0011
+            13, // 1011
+            14, // 0111
+            15, // 1111
+    };
+    const std::vector<std::uint64_t> expectedOutputStates = {
+            1,  // 1000
+            2,  // 0100
+            3,  // 1100
+            0,  // 0000
+            5,  // 1010
+            6,  // 0110
+            7,  // 1110
+            4,  // 0010
+            9,  // 1001
+            10, // 0101
+            11, // 1101
+            8,  // 0001
+            13, // 1011
+            14, // 0111
+            15, // 1111
+            12, // 0011
+    };
+
+    for (std::size_t i = 0; i < inputStatesToCheck.size(); ++i) {
+        const syrec::NBitValuesContainer inputState(this->annotatableQuantumComputation.getNqubits(), inputStatesToCheck[i]);
+        const syrec::NBitValuesContainer expectedOutputState(inputState.size(), expectedOutputStates[i]);
+        ASSERT_NO_FATAL_FAILURE(this->assertSimulationResultForStateMatchesExpectedOne(inputState, expectedOutputState));
+    }
+}
+
+TYPED_TEST_P(BaseSimulationTestFixture, IncrementBitrangeOfValueOfDimensionOfVariableWithBitrangeStartEqualToEnd) {
+    syrec::Program program;
+    ASSERT_NO_FATAL_FAILURE(parseSyrecProgram("module main(inout a[2](2)) ++= a[0].1:1", program));
+    ASSERT_TRUE(this->performProgramSynthesis(program));
+
+    const std::vector<std::uint64_t> inputStatesToCheck = {
+            0,  // 0000
+            1,  // 1000
+            2,  // 0100
+            3,  // 1100
+            4,  // 0010
+            5,  // 1010
+            6,  // 0110
+            7,  // 1110
+            8,  // 0001
+            9,  // 1001
+            10, // 0101
+            11, // 1101
+            12, // 0011
+            13, // 1011
+            14, // 0111
+            15, // 1111
+    };
+    const std::vector<std::uint64_t> expectedOutputStates = {
+            2,  // 0100
+            3,  // 1100
+            0,  // 0000
+            1,  // 1000
+            6,  // 0110
+            7,  // 1110
+            4,  // 0010
+            5,  // 1010
+            10, // 0101
+            11, // 1101
+            8,  // 0001
+            9,  // 1001
+            14, // 0111
+            15, // 1111
+            12, // 0011
+            13, // 1011
+    };
+
+    for (std::size_t i = 0; i < inputStatesToCheck.size(); ++i) {
+        constexpr std::size_t            inputStateSize = 4;
         const syrec::NBitValuesContainer inputState(inputStateSize, inputStatesToCheck[i]);
         const syrec::NBitValuesContainer expectedOutputState(inputStateSize, expectedOutputStates[i]);
         ASSERT_NO_FATAL_FAILURE(this->assertSimulationResultForStateMatchesExpectedOne(inputState, expectedOutputState));
@@ -361,7 +1336,29 @@ REGISTER_TYPED_TEST_SUITE_P(BaseSimulationTestFixture,
                             BitwiseNegationOfBinaryExpression,
                             BitwiseNegationOfShiftExpression,
                             BitwiseNegationOfUnaryExpression,
-                            FourBitAddition);
+                            AddAssignWithRightHandSideEqualToVariable,
+                            AddAssignWithRightHandSideEqualToConstant,
+                            AddAssignWithRightHandSideEqualToBinaryExpression,
+                            AddAssignWithRightHandSideEqualToShiftExpression,
+                            AddAssignWithRightHandSideEqualToUnaryExpression,
+                            AddAssignWithRightHandSideEqualToNestedExpression,
+                            AddAssignOfBitOfVariable,
+                            AddAssignOfBitrangeOfVariableWithStartSmallerThanEnd,
+                            AddAssignOfBitrangeOfVariableWithStartLargerThanEnd,
+                            AddAssignOfValueOfDimensionOfVariable,
+                            AddAssignOfBitOfValueOfDimensionOfVariable,
+                            AddAssignOfBitrangeOfValueOfDimensionOfVariableWithStartSmallerThanEnd,
+                            AddAssignOfBitrangeOfValueOfDimensionOfVariableWithStartLargerThanEnd,
+                            AddAssignOfBitrangeOfValueOfDimensionOfVariableWithStartEqualToEnd,
+                            IncrementAssignOfVariable,
+                            IncrementAssignOfBitOfVariable,
+                            IncrementAssignOfBitrangeOfVariableWithBitrangeStartSmallerThanEnd,
+                            IncrementAssignOfBitrangeOfVariableWithBitrangeStartLargerThanEnd,
+                            IncrementValueOfDimensionOfVariable,
+                            IncrementBitOfValueOfDimensionOfVariable,
+                            IncrementBitrangeOfValueOfDimensionOfVariableWithBitrangeStartSmallerThanEnd,
+                            IncrementBitrangeOfValueOfDimensionOfVariableWithBitrangeStartLargerThanEnd,
+                            IncrementBitrangeOfValueOfDimensionOfVariableWithBitrangeStartEqualToEnd);
 
 using SynthesizerTypes = testing::Types<syrec::CostAwareSynthesis, syrec::LineAwareSynthesis>;
 INSTANTIATE_TYPED_TEST_SUITE_P(SyrecSynthesisTest, BaseSimulationTestFixture, SynthesizerTypes, );

--- a/test/unittests/simulation/test_synthesis_basic_operations.cpp
+++ b/test/unittests/simulation/test_synthesis_basic_operations.cpp
@@ -291,7 +291,6 @@ TYPED_TEST_P(BaseSimulationTestFixture, BitwiseNegationOfUnaryExpression) {
     }
 }
 
-// TODO: Should error cases in synthesis be checked (that should already be handled by the parser)?
 TYPED_TEST_P(BaseSimulationTestFixture, AddAssignWithRightHandSideEqualToVariable) {
     syrec::Program program;
     ASSERT_NO_FATAL_FAILURE(parseSyrecProgram("module main(inout a(4), in b(4)) a += b", program));
@@ -366,55 +365,6 @@ TYPED_TEST_P(BaseSimulationTestFixture, AddAssignWithRightHandSideEqualToConstan
             7, // 111XX
             0, // 000XX
             1, // 100XX
-    };
-
-    for (std::size_t i = 0; i < inputStatesToCheck.size(); ++i) {
-        const syrec::NBitValuesContainer inputState(this->annotatableQuantumComputation.getNqubits(), inputStatesToCheck[i]);
-        const syrec::NBitValuesContainer expectedOutputState(inputState.size(), expectedOutputStates[i]);
-        ASSERT_NO_FATAL_FAILURE(this->assertSimulationResultForStateMatchesExpectedOne(inputState, expectedOutputState));
-    }
-}
-
-TYPED_TEST_P(BaseSimulationTestFixture, AddAssignWithRightHandSideEqualToBinaryExpression) {
-    syrec::Program program;
-    ASSERT_NO_FATAL_FAILURE(parseSyrecProgram("module main(inout a(2), in b(2)) a += (b + 1)", program));
-    ASSERT_TRUE(this->performProgramSynthesis(program));
-
-    const std::vector<std::uint64_t> inputStatesToCheck = {
-            0,  // 0000XXXX
-            1,  // 1000XXXX
-            2,  // 0100XXXX
-            3,  // 1100XXXX
-            4,  // 0010XXXX
-            5,  // 1010XXXX
-            6,  // 0110XXXX
-            7,  // 1110XXXX
-            8,  // 0001XXXX
-            9,  // 1001XXXX
-            10, // 0101XXXX
-            11, // 1101XXXX
-            12, // 0011XXXX
-            13, // 1011XXXX
-            14, // 0111XXXX
-            15, // 1111XXXX
-    };
-    const std::vector<std::uint64_t> expectedOutputStates = {
-            1,  // 1000XXXX
-            2,  // 0100XXXX
-            3,  // 1100XXXX
-            0,  // 0000XXXX
-            6,  // 0110XXXX
-            7,  // 1110XXXX
-            4,  // 0010XXXX
-            5,  // 1010XXXX
-            11, // 1101XXXX
-            8,  // 0001XXXX
-            9,  // 1001XXXX
-            10, // 0101XXXX
-            12, // 0011XXXX
-            13, // 1011XXXX
-            14, // 0111XXXX
-            15, // 1111XXXX
     };
 
     for (std::size_t i = 0; i < inputStatesToCheck.size(); ++i) {
@@ -1338,7 +1288,6 @@ REGISTER_TYPED_TEST_SUITE_P(BaseSimulationTestFixture,
                             BitwiseNegationOfUnaryExpression,
                             AddAssignWithRightHandSideEqualToVariable,
                             AddAssignWithRightHandSideEqualToConstant,
-                            AddAssignWithRightHandSideEqualToBinaryExpression,
                             AddAssignWithRightHandSideEqualToShiftExpression,
                             AddAssignWithRightHandSideEqualToUnaryExpression,
                             AddAssignWithRightHandSideEqualToNestedExpression,

--- a/test/unittests/simulation/test_synthesis_basic_operations.cpp
+++ b/test/unittests/simulation/test_synthesis_basic_operations.cpp
@@ -299,6 +299,57 @@ TYPED_TEST_P(BaseSimulationTestFixture, BitwiseNegationOfUnaryExpression) {
     }
 }
 
+TYPED_TEST_P(BaseSimulationTestFixture, FourBitAddition) {
+    syrec::Program program;
+    ASSERT_NO_FATAL_FAILURE(parseSyrecProgram("module main(inout a(4), in b(4)) a += b", program));
+    ASSERT_TRUE(this->performProgramSynthesis(program));
+
+    // State is defined starting with lowest qubit -> highest qubit (thus a binary string is read from left to right)
+    const std::vector<std::uint64_t> inputStatesToCheck = {
+            0,   // 0000 0000
+            16,  // 0000 1000
+            32,  // 0000 0100
+            48,  // 0000 1100
+            64,  // 0000 0010
+            80,  // 0000 1010
+            96,  // 0000 0110
+            112, // 0000 1110
+            128, // 0000 0001
+            144, // 0000 1001
+            160, // 0000 0101
+            176, // 0000 1101
+            192, // 0000 0011
+            208, // 0000 1011
+            224, // 0000 0111
+            240, // 0000 1111
+    };
+    const std::vector<std::uint64_t> expectedOutputStates = {
+            0,   // 0000 0000
+            17,  // 1000 1000
+            34,  // 0100 0100
+            51,  // 1100 1100
+            68,  // 0010 0010
+            85,  // 1010 1010
+            102, // 0110 0110
+            119, // 1110 1110
+            136, // 0001 0001
+            153, // 1001 1001
+            170, // 0101 0101
+            187, // 1101 1101
+            204, // 0011 0011
+            221, // 1011 1011
+            238, // 0111 0111
+            255, // 1111 1111
+    };
+
+    for (std::size_t i = 0; i < inputStatesToCheck.size(); ++i) {
+        constexpr std::size_t            inputStateSize = 8;
+        const syrec::NBitValuesContainer inputState(inputStateSize, inputStatesToCheck[i]);
+        const syrec::NBitValuesContainer expectedOutputState(inputStateSize, expectedOutputStates[i]);
+        ASSERT_NO_FATAL_FAILURE(this->assertSimulationResultForStateMatchesExpectedOne(inputState, expectedOutputState));
+    }
+}
+
 REGISTER_TYPED_TEST_SUITE_P(BaseSimulationTestFixture,
                             LogicalNegationOfConstantZero,
                             LogicalNegationOfConstantOne,
@@ -309,7 +360,8 @@ REGISTER_TYPED_TEST_SUITE_P(BaseSimulationTestFixture,
                             BitwiseNegationOfVariable,
                             BitwiseNegationOfBinaryExpression,
                             BitwiseNegationOfShiftExpression,
-                            BitwiseNegationOfUnaryExpression);
+                            BitwiseNegationOfUnaryExpression,
+                            FourBitAddition);
 
 using SynthesizerTypes = testing::Types<syrec::CostAwareSynthesis, syrec::LineAwareSynthesis>;
 INSTANTIATE_TYPED_TEST_SUITE_P(SyrecSynthesisTest, BaseSimulationTestFixture, SynthesizerTypes, );


### PR DESCRIPTION
## Description

- With this PR the counter-examples found in #254  can be correctly synthesized due to bugfixes in the `SyrecSynthesis::increase` operation. Additionally, further tests of the binary `+` operation as well as the assignment operations `+=` and `++=` are added that check that a simulation of these operations returns the correct results (the expected synthesis costs are not defined).

- Various algorithms that can be used fix the errors of `SyrecSynthesis::increase` were proposed in #254 but since the pre-PR implementation already followed one of these algorithms (with the algorithm of "Quantum Addition Circuits and Unbounded Fan-Out" ([Takahashi et al.](https://arxiv.org/abs/0910.2530v1)) being the closest match) no complete reimplementation was needed.

- Some simulation tests could not be added in the PR due to errors in the `LineAwareSynthesis` (e.g., see #280)

- A breaking change in the internal `SyrecSynthesis` interface was added due to the unification of the `SyrecSynthesis::increase` and `SyrecSynthesis::increaseWithCarry` into one function.

Fixes #254

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [X] The pull request only contains commits that are related to it.
- [X] I have added appropriate tests and documentation.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [X] The pull request introduces no new warnings and follows the project's style guidelines.
