### PR TITLE
Use ancillary qubit to store result of synthesis of variable expression used as guard condition in IfStatement

### DIFF
--- a/include/core/annotatable_quantum_computation.hpp
+++ b/include/core/annotatable_quantum_computation.hpp
@@ -35,11 +35,11 @@ namespace syrec {
         using QuantumOperationAnnotationsLookup = std::map<std::string, std::string, std::less<>>;
         using SynthesisCostMetricValue          = std::uint64_t;
 
-        [[maybe_unused]] bool addOperationsImplementingNotGate(qc::Qubit targetQubit);
-        [[maybe_unused]] bool addOperationsImplementingCnotGate(qc::Qubit controlQubit, qc::Qubit targetQubit);
-        [[maybe_unused]] bool addOperationsImplementingToffoliGate(qc::Qubit controlQubitOne, qc::Qubit controlQubitTwo, qc::Qubit targetQubit);
-        [[maybe_unused]] bool addOperationsImplementingMultiControlToffoliGate(const qc::Controls& controlQubitsSet, qc::Qubit targetQubit);
-        [[maybe_unused]] bool addOperationsImplementingFredkinGate(qc::Qubit targetQubitOne, qc::Qubit targetQubitTwo);
+        [[nodiscard]] bool addOperationsImplementingNotGate(qc::Qubit targetQubit);
+        [[nodiscard]] bool addOperationsImplementingCnotGate(qc::Qubit controlQubit, qc::Qubit targetQubit);
+        [[nodiscard]] bool addOperationsImplementingToffoliGate(qc::Qubit controlQubitOne, qc::Qubit controlQubitTwo, qc::Qubit targetQubit);
+        [[nodiscard]] bool addOperationsImplementingMultiControlToffoliGate(const qc::Controls& controlQubitsSet, qc::Qubit targetQubit);
+        [[nodiscard]] bool addOperationsImplementingFredkinGate(qc::Qubit targetQubitOne, qc::Qubit targetQubitTwo);
 
         /**
          * Add a non-ancillary qubit to the quantum computation.
@@ -108,7 +108,7 @@ namespace syrec {
          * @param controlQubit The control qubit to deregister
          * @return Whether the control qubit exists in the internally used qc::QuantumComputation and was deregistered from the last activated propagation scope.
          */
-        [[maybe_unused]] bool deregisterControlQubitFromPropagationInCurrentScope(qc::Qubit controlQubit);
+        [[nodiscard]] bool deregisterControlQubitFromPropagationInCurrentScope(qc::Qubit controlQubit);
 
         /**
          * Register a control qubit in the last activated control qubit propagation scope.
@@ -117,7 +117,7 @@ namespace syrec {
          * @param controlQubit The control qubit to register
          * @return Whether the control qubit exists in the \p quantumComputation and was registered in the last activated propagation scope.
          */
-        [[maybe_unused]] bool registerControlQubitForPropagationInCurrentAndNestedScopes(qc::Qubit controlQubit);
+        [[nodiscard]] bool registerControlQubitForPropagationInCurrentAndNestedScopes(qc::Qubit controlQubit);
 
         /**
          * Register or update a global quantum operation annotation. Global quantum operation annotations are added to all quantum operations added to the internally used qc::QuantumComputation.

--- a/src/algorithms/synthesis/syrec_synthesis.cpp
+++ b/src/algorithms/synthesis/syrec_synthesis.cpp
@@ -265,33 +265,18 @@ namespace syrec {
         // add new helper line
         const qc::Qubit helperLine = expressionResult.front();
         annotatableQuantumComputation.activateControlQubitPropagationScope();
-        annotatableQuantumComputation.registerControlQubitForPropagationInCurrentAndNestedScopes(helperLine);
-
-        for (const Statement::ptr& stat: statement.thenStatements) {
-            if (!processStatement(stat)) {
-                return false;
-            }
-        }
+        bool synthesisOfBranchStatementsOk = annotatableQuantumComputation.registerControlQubitForPropagationInCurrentAndNestedScopes(helperLine) && std::all_of(statement.thenStatements.cbegin(), statement.thenStatements.cend(), [&](const Statement::ptr& trueBranchStatement) { return processStatement(trueBranchStatement); });
 
         // Toggle helper line.
         // We do not want to use the current helper line controlling the conditional execution of the statements
         // of both branches of the current IfStatement when negating the value of said helper line
-        annotatableQuantumComputation.deregisterControlQubitFromPropagationInCurrentScope(helperLine);
-        annotatableQuantumComputation.addOperationsImplementingNotGate(helperLine);
-        annotatableQuantumComputation.registerControlQubitForPropagationInCurrentAndNestedScopes(helperLine);
-
-        for (const Statement::ptr& stat: statement.elseStatements) {
-            if (!processStatement(stat)) {
-                return false;
-            }
-        }
+        synthesisOfBranchStatementsOk &= annotatableQuantumComputation.deregisterControlQubitFromPropagationInCurrentScope(helperLine) && annotatableQuantumComputation.addOperationsImplementingNotGate(helperLine) && annotatableQuantumComputation.registerControlQubitForPropagationInCurrentAndNestedScopes(helperLine) && std::all_of(statement.elseStatements.cbegin(), statement.elseStatements.cend(), [&](const Statement::ptr& falseBranchStatement) { return processStatement(falseBranchStatement); });
 
         // We do not want to use the current helper line controlling the conditional execution of the statements
         // of both branches of the current IfStatement when negating the value of said helper line
-        annotatableQuantumComputation.deregisterControlQubitFromPropagationInCurrentScope(helperLine);
-        annotatableQuantumComputation.addOperationsImplementingNotGate(helperLine);
+        synthesisOfBranchStatementsOk &= annotatableQuantumComputation.deregisterControlQubitFromPropagationInCurrentScope(helperLine) && annotatableQuantumComputation.addOperationsImplementingNotGate(helperLine);
         annotatableQuantumComputation.deactivateControlQubitPropagationScope();
-        return true;
+        return synthesisOfBranchStatementsOk;
     }
 
     bool SyrecSynthesis::onStatement(const ForStatement& statement) {
@@ -634,8 +619,7 @@ namespace syrec {
         annotatableQuantumComputation.activateControlQubitPropagationScope();
         bool synthesisOk = true;
         for (std::size_t i = 0; i < dest.size() && synthesisOk; ++i) {
-            synthesisOk = annotatableQuantumComputation.addOperationsImplementingNotGate(dest[i]);
-            annotatableQuantumComputation.registerControlQubitForPropagationInCurrentAndNestedScopes(dest[i]);
+            synthesisOk = annotatableQuantumComputation.addOperationsImplementingNotGate(dest[i]) && annotatableQuantumComputation.registerControlQubitForPropagationInCurrentAndNestedScopes(dest[i]);
         }
         annotatableQuantumComputation.deactivateControlQubitPropagationScope();
         return synthesisOk;
@@ -643,14 +627,14 @@ namespace syrec {
 
     bool SyrecSynthesis::increment(AnnotatableQuantumComputation& annotatableQuantumComputation, const std::vector<qc::Qubit>& dest) {
         annotatableQuantumComputation.activateControlQubitPropagationScope();
-        for (const auto line: dest) {
-            annotatableQuantumComputation.registerControlQubitForPropagationInCurrentAndNestedScopes(line);
-        }
 
         bool synthesisOk = true;
+        for (std::size_t i = 0; i < dest.size() && synthesisOk; ++i) {
+            synthesisOk = annotatableQuantumComputation.registerControlQubitForPropagationInCurrentAndNestedScopes(dest.at(i));
+        }
+
         for (int i = static_cast<int>(dest.size()) - 1; i >= 0 && synthesisOk; --i) {
-            annotatableQuantumComputation.deregisterControlQubitFromPropagationInCurrentScope(dest[static_cast<std::size_t>(i)]);
-            synthesisOk = annotatableQuantumComputation.addOperationsImplementingNotGate(dest[static_cast<std::size_t>(i)]);
+            synthesisOk = annotatableQuantumComputation.deregisterControlQubitFromPropagationInCurrentScope(dest[static_cast<std::size_t>(i)]) && annotatableQuantumComputation.addOperationsImplementingNotGate(dest[static_cast<std::size_t>(i)]);
         }
         annotatableQuantumComputation.deactivateControlQubitPropagationScope();
         return synthesisOk;
@@ -669,9 +653,9 @@ namespace syrec {
     }
 
     bool SyrecSynthesis::bitwiseCnot(AnnotatableQuantumComputation& annotatableQuantumComputation, const std::vector<qc::Qubit>& dest, const std::vector<qc::Qubit>& src) {
-        const bool synthesisOk = dest.size() >= src.size();
+        bool synthesisOk = dest.size() >= src.size();
         for (std::size_t i = 0; i < src.size() && synthesisOk; ++i) {
-            annotatableQuantumComputation.addOperationsImplementingCnotGate(src[i], dest[i]);
+            synthesisOk = annotatableQuantumComputation.addOperationsImplementingCnotGate(src[i], dest[i]);
         }
         return synthesisOk;
     }
@@ -743,21 +727,20 @@ namespace syrec {
             synthesisOk = decreaseWithCarry(annotatableQuantumComputation, truncatedAggregateOfRemainderAndQuotientQubits, divisor, signBitOfSubtraction);
 
             // The restore operation of the aggregate variable should only be performed when Y < 0.
-            annotatableQuantumComputation.registerControlQubitForPropagationInCurrentAndNestedScopes(signBitOfSubtraction);
+            synthesisOk &= annotatableQuantumComputation.registerControlQubitForPropagationInCurrentAndNestedScopes(signBitOfSubtraction);
 
             // Y = Y + divisor
-            synthesisOk &= increase(annotatableQuantumComputation, truncatedAggregateOfRemainderAndQuotientQubits, divisor);
-            annotatableQuantumComputation.deregisterControlQubitFromPropagationInCurrentScope(signBitOfSubtraction);
+            synthesisOk &= increase(annotatableQuantumComputation, truncatedAggregateOfRemainderAndQuotientQubits, divisor) && annotatableQuantumComputation.deregisterControlQubitFromPropagationInCurrentScope(signBitOfSubtraction);
 
             // After the 'restoring' operation for the variable V was performed, the final value of the remainder qubit can be set (remainder[i] = NOT(sign bit)).
-            annotatableQuantumComputation.addOperationsImplementingNotGate(signBitOfSubtraction);
+            synthesisOk &= annotatableQuantumComputation.addOperationsImplementingNotGate(signBitOfSubtraction);
         }
         annotatableQuantumComputation.deactivateControlQubitPropagationScope();
 
         // While the description of the reference algorithm states that the qubits of the quotient and remainder at this point store the values of the quotient and remainder respectively,
         // manual executions of the algorithm resulted in the quotient qubits storing the value of the remainder and vice versa, thus a final swap of the quotient and remainder qubits is required.
-        for (std::size_t i = 0; i < operandBitwidth; ++i) {
-            annotatableQuantumComputation.addOperationsImplementingFredkinGate(quotient[i], remainder[i]);
+        for (std::size_t i = 0; i < operandBitwidth && synthesisOk; ++i) {
+            synthesisOk = annotatableQuantumComputation.addOperationsImplementingFredkinGate(quotient[i], remainder[i]);
         }
         return synthesisOk;
     }
@@ -888,16 +871,12 @@ namespace syrec {
         std::vector<qc::Qubit> partial = src2;
 
         annotatableQuantumComputation.activateControlQubitPropagationScope();
-        annotatableQuantumComputation.registerControlQubitForPropagationInCurrentAndNestedScopes(src1.front());
-        bool synthesisOk = bitwiseCnot(annotatableQuantumComputation, sum, partial);
-        annotatableQuantumComputation.deregisterControlQubitFromPropagationInCurrentScope(src1.front());
+        bool synthesisOk = annotatableQuantumComputation.registerControlQubitForPropagationInCurrentAndNestedScopes(src1.front()) && bitwiseCnot(annotatableQuantumComputation, sum, partial) && annotatableQuantumComputation.deregisterControlQubitFromPropagationInCurrentScope(src1.front());
 
         for (std::size_t i = 1; i < dest.size() && synthesisOk; ++i) {
             sum.erase(sum.begin());
             partial.pop_back();
-            annotatableQuantumComputation.registerControlQubitForPropagationInCurrentAndNestedScopes(src1[i]);
-            synthesisOk = increase(annotatableQuantumComputation, sum, partial);
-            annotatableQuantumComputation.deregisterControlQubitFromPropagationInCurrentScope(src1[i]);
+            synthesisOk = annotatableQuantumComputation.registerControlQubitForPropagationInCurrentAndNestedScopes(src1[i]) && increase(annotatableQuantumComputation, sum, partial) && annotatableQuantumComputation.deregisterControlQubitFromPropagationInCurrentScope(src1[i]);
         }
         annotatableQuantumComputation.deactivateControlQubitPropagationScope();
         return synthesisOk;
@@ -1002,7 +981,9 @@ namespace syrec {
         } else if (!freeConstLinesMap[!value].empty()) {
             constLine = freeConstLinesMap[!value].back();
             freeConstLinesMap[!value].pop_back();
-            annotatableQuantumComputation.addOperationsImplementingNotGate(constLine);
+            if (!annotatableQuantumComputation.addOperationsImplementingNotGate(constLine)) {
+                return std::nullopt;
+            }
         } else {
             const auto                     qubitIndex          = static_cast<qc::Qubit>(annotatableQuantumComputation.getNqubits());
             const std::string              qubitLabel          = "q_" + std::to_string(qubitIndex) + "_const_" + std::to_string(static_cast<int>(value));

--- a/src/algorithms/synthesis/syrec_synthesis.cpp
+++ b/src/algorithms/synthesis/syrec_synthesis.cpp
@@ -254,27 +254,40 @@ namespace syrec {
         }
 
         // calculate expression
-        std::vector<qc::Qubit> expressionResult;
-        const bool             synthesisOfGuardExprOk = onExpression(statement.condition, expressionResult, {}, guardExpressionTopLevelOperation);
+        std::vector<qc::Qubit> guardExpressionQubits;
+        bool                   synthesisOfGuardExprOk = onExpression(statement.condition, guardExpressionQubits, {}, guardExpressionTopLevelOperation);
+        assert(guardExpressionQubits.size() == 1U);
 
-        assert(expressionResult.size() == 1U);
+        // We need to create the ancillary qubit used to store the synthesis result of the variable expression since the onExpression(...) function does not create this ancillary qubit
+        // Additionally, a CNOT gate is required to transfer the value of the current qubit storing the synthesis result of the VariableExpression to the ancillary qubit.
+        // The ancillary qubit is only required when the original qubit of the guard expression is used as a target qubit in any of the statements of the true
+        // or false branch of the IfStatement but since we cannot determine whether this case will happen (at this point of the synthesis) we are 'forced' to use the ancillary qubit.
+        if (auto const* variableExpr = dynamic_cast<VariableExpression*>(statement.condition.get()); variableExpr != nullptr && synthesisOfGuardExprOk) {
+            if (const std::optional<qc::Qubit> generatedHelperLine = getConstantLine(false); generatedHelperLine.has_value()) {
+                synthesisOfGuardExprOk   = annotatableQuantumComputation.addOperationsImplementingCnotGate(guardExpressionQubits.front(), *generatedHelperLine);
+                guardExpressionQubits[0] = *generatedHelperLine;
+            } else {
+                synthesisOfGuardExprOk = false;
+            }
+        }
+
         if (!synthesisOfGuardExprOk) {
             return false;
         }
 
         // add new helper line
-        const qc::Qubit helperLine = expressionResult.front();
+        const qc::Qubit guardExpressionQubit = guardExpressionQubits.front();
         annotatableQuantumComputation.activateControlQubitPropagationScope();
-        bool synthesisOfBranchStatementsOk = annotatableQuantumComputation.registerControlQubitForPropagationInCurrentAndNestedScopes(helperLine) && std::all_of(statement.thenStatements.cbegin(), statement.thenStatements.cend(), [&](const Statement::ptr& trueBranchStatement) { return processStatement(trueBranchStatement); });
+        bool synthesisOfBranchStatementsOk = annotatableQuantumComputation.registerControlQubitForPropagationInCurrentAndNestedScopes(guardExpressionQubit) && std::all_of(statement.thenStatements.cbegin(), statement.thenStatements.cend(), [&](const Statement::ptr& trueBranchStatement) { return processStatement(trueBranchStatement); });
 
         // Toggle helper line.
         // We do not want to use the current helper line controlling the conditional execution of the statements
         // of both branches of the current IfStatement when negating the value of said helper line
-        synthesisOfBranchStatementsOk &= annotatableQuantumComputation.deregisterControlQubitFromPropagationInCurrentScope(helperLine) && annotatableQuantumComputation.addOperationsImplementingNotGate(helperLine) && annotatableQuantumComputation.registerControlQubitForPropagationInCurrentAndNestedScopes(helperLine) && std::all_of(statement.elseStatements.cbegin(), statement.elseStatements.cend(), [&](const Statement::ptr& falseBranchStatement) { return processStatement(falseBranchStatement); });
+        synthesisOfBranchStatementsOk &= annotatableQuantumComputation.deregisterControlQubitFromPropagationInCurrentScope(guardExpressionQubit) && annotatableQuantumComputation.addOperationsImplementingNotGate(guardExpressionQubit) && annotatableQuantumComputation.registerControlQubitForPropagationInCurrentAndNestedScopes(guardExpressionQubit) && std::all_of(statement.elseStatements.cbegin(), statement.elseStatements.cend(), [&](const Statement::ptr& falseBranchStatement) { return processStatement(falseBranchStatement); });
 
         // We do not want to use the current helper line controlling the conditional execution of the statements
         // of both branches of the current IfStatement when negating the value of said helper line
-        synthesisOfBranchStatementsOk &= annotatableQuantumComputation.deregisterControlQubitFromPropagationInCurrentScope(helperLine) && annotatableQuantumComputation.addOperationsImplementingNotGate(helperLine);
+        synthesisOfBranchStatementsOk &= annotatableQuantumComputation.deregisterControlQubitFromPropagationInCurrentScope(guardExpressionQubit) && annotatableQuantumComputation.addOperationsImplementingNotGate(guardExpressionQubit);
         annotatableQuantumComputation.deactivateControlQubitPropagationScope();
         return synthesisOfBranchStatementsOk;
     }

--- a/test/circuits/constExpr_8.src
+++ b/test/circuits/constExpr_8.src
@@ -1,5 +1,5 @@
 module main(in a(8), out res(8))
-	for $i = 0 to #a step 2 do
+	for $i = 0 to (#a - 2) step 2 do
 		res.$i ^= a.($i + 1);
 		res.($i +1) ^= a.$i
 	rof

--- a/test/configs/circuits_cost_aware_synthesis.json
+++ b/test/configs/circuits_cost_aware_synthesis.json
@@ -1,9 +1,9 @@
 {
   "alu_2": {
-    "num_gates": 26,
-    "lines": 11,
-    "quantum_costs": 138,
-    "transistor_costs": 384
+    "num_gates": 27,
+    "lines": 12,
+    "quantum_costs": 139,
+    "transistor_costs": 392
   },
 
   "binary_numeric": {
@@ -35,10 +35,10 @@
   },
 
   "call_8": {
-    "num_gates": 212,
-    "lines": 41,
-    "quantum_costs": 1492,
-    "transistor_costs": 3776
+    "num_gates": 214,
+    "lines": 43,
+    "quantum_costs": 1494,
+    "transistor_costs": 3792
   },
   "constExpr_8": {
     "num_gates": 8,
@@ -54,10 +54,10 @@
   },
 
   "foldEval_4": {
-    "num_gates": 42,
-    "lines": 33,
-    "quantum_costs": 202,
-    "transistor_costs": 640
+    "num_gates": 43,
+    "lines": 34,
+    "quantum_costs": 203,
+    "transistor_costs": 648
   },
 
   "for_4": {
@@ -68,17 +68,17 @@
   },
 
   "for_32": {
-    "num_gates": 2498,
-    "lines": 641,
-    "quantum_costs": 15426,
-    "transistor_costs": 41856
+    "num_gates": 2499,
+    "lines": 642,
+    "quantum_costs": 15427,
+    "transistor_costs": 41864
   },
 
   "gray_binary_conversion_16": {
-    "num_gates": 94,
-    "lines": 63,
-    "quantum_costs": 462,
-    "transistor_costs": 1472
+    "num_gates": 95,
+    "lines": 64,
+    "quantum_costs": 463,
+    "transistor_costs": 1480
   },
 
   "ifCondVariants_4": {
@@ -159,17 +159,17 @@
   },
 
   "parity_4": {
-    "num_gates": 17,
-    "lines": 12,
-    "quantum_costs": 73,
-    "transistor_costs": 232
+    "num_gates": 18,
+    "lines": 13,
+    "quantum_costs": 74,
+    "transistor_costs": 240
   },
 
   "parity_check_16": {
-    "num_gates": 69,
-    "lines": 51,
-    "quantum_costs": 333,
-    "transistor_costs": 1064
+    "num_gates": 70,
+    "lines": 52,
+    "quantum_costs": 334,
+    "transistor_costs": 1072
   },
   "relationalOp_4": {
     "num_gates": 373,

--- a/test/configs/circuits_line_aware_synthesis.json
+++ b/test/configs/circuits_line_aware_synthesis.json
@@ -1,9 +1,9 @@
 {
   "alu_2": {
-    "num_gates": 46,
-    "lines": 7,
-    "quantum_costs": 222,
-    "transistor_costs": 640
+    "num_gates": 47,
+    "lines": 8,
+    "quantum_costs": 223,
+    "transistor_costs": 648
   },
 
   "binary_numeric": {
@@ -35,10 +35,10 @@
   },
 
   "call_8": {
-    "num_gates": 196,
-    "lines": 25,
-    "quantum_costs": 1412,
-    "transistor_costs": 3520
+    "num_gates": 198,
+    "lines": 27,
+    "quantum_costs": 1414,
+    "transistor_costs": 3536
   },
   "constExpr_8": {
     "num_gates": 8,
@@ -59,22 +59,22 @@
     "transistor_costs": 1792
   },
   "foldEval_4": {
-    "num_gates": 34,
-    "lines": 17,
-    "quantum_costs": 162,
-    "transistor_costs": 512
+    "num_gates": 35,
+    "lines": 18,
+    "quantum_costs": 163,
+    "transistor_costs": 520
   },
   "for_32": {
-    "num_gates": 4738,
-    "lines": 385,
-    "quantum_costs": 27522,
-    "transistor_costs": 75520
+    "num_gates": 4739,
+    "lines": 386,
+    "quantum_costs": 27523,
+    "transistor_costs": 75528
   },
   "gray_binary_conversion_16": {
-    "num_gates": 64,
-    "lines": 33,
-    "quantum_costs": 312,
-    "transistor_costs": 992
+    "num_gates": 65,
+    "lines": 34,
+    "quantum_costs": 313,
+    "transistor_costs": 1000
   },
   "ifCondVariants_4": {
     "num_gates": 252,
@@ -143,16 +143,16 @@
     "transistor_costs": 2240
   },
   "parity_4": {
-    "num_gates": 15,
-    "lines": 6,
-    "quantum_costs": 63,
-    "transistor_costs": 200
+    "num_gates": 16,
+    "lines": 7,
+    "quantum_costs": 64,
+    "transistor_costs": 208
   },
   "parity_check_16": {
-    "num_gates": 67,
-    "lines": 19,
-    "quantum_costs": 323,
-    "transistor_costs": 1032
+    "num_gates": 68,
+    "lines": 20,
+    "quantum_costs": 324,
+    "transistor_costs": 1040
   },
   "relationalOp_4": {
     "num_gates": 373,

--- a/test/unittests/simulation/data/test_synthesis_of_basic_operations.json
+++ b/test/unittests/simulation/data/test_synthesis_of_basic_operations.json
@@ -3672,5 +3672,89 @@
         "out": "1011"
       }
     ]
+  },
+  "AccessOnSameQubitOfGuardConditionPossibleOnLefthandSideOfAssignment": {
+    "inputCircuit": "module main(inout a(2)) if a.1 then a.1 ^= 1 else skip fi a.1",
+    "simulationRuns": [
+      {
+        "in": "00",
+        "out": "00"
+      },
+      {
+        "in": "10",
+        "out": "10"
+      },
+      {
+        "in": "01",
+        "out": "00"
+      },
+      {
+        "in": "11",
+        "out": "10"
+      }
+    ]
+  },
+  "OverlappingAccessOnQubitOfGuardConditionPossibleOnLefthandSideOfAssignment": {
+    "inputCircuit": "module main(inout a(2)) if a.1 then a += 1 else skip fi a.1",
+    "simulationRuns": [
+      {
+        "in": "00",
+        "out": "00"
+      },
+      {
+        "in": "10",
+        "out": "10"
+      },
+      {
+        "in": "01",
+        "out": "11"
+      },
+      {
+        "in": "11",
+        "out": "00"
+      }
+    ]
+  },
+  "AccessOnSameQubitOfGuardConditionPossibleOnRighthandSideOfAssignmentUsingPrefixAssignmentOperand": {
+    "inputCircuit": "module main(inout a(2)) if a.1 then ++= a.1 else skip fi a.1",
+    "simulationRuns": [
+      {
+        "in": "00",
+        "out": "00"
+      },
+      {
+        "in": "10",
+        "out": "10"
+      },
+      {
+        "in": "01",
+        "out": "00"
+      },
+      {
+        "in": "11",
+        "out": "10"
+      }
+    ]
+  },
+  "OverlappingAccessOnQubitOfGuardConditionPossibleOnRighthandSideOfAssignmentUsingPrefixAssignmentOperand": {
+    "inputCircuit": "module main(inout a(2)) if a.1 then ++= a else skip fi a.1",
+    "simulationRuns": [
+      {
+        "in": "00",
+        "out": "00"
+      },
+      {
+        "in": "10",
+        "out": "10"
+      },
+      {
+        "in": "01",
+        "out": "11"
+      },
+      {
+        "in": "11",
+        "out": "00"
+      }
+    ]
   }
 }

--- a/test/unittests/simulation/test_synthesis_basic_operations.cpp
+++ b/test/unittests/simulation/test_synthesis_basic_operations.cpp
@@ -284,6 +284,22 @@ TYPED_TEST_P(BaseSimulationTestFixture, IncrementBitrangeOfValueOfDimensionOfVar
     this->performTestExecutionForCircuitLoadedFromJson(RELATIVE_PATH_TO_TEST_CASE_DATA_JSON_FILE, this->getNameOfCurrentlyExecutedTest());
 }
 
+TYPED_TEST_P(BaseSimulationTestFixture, AccessOnSameQubitOfGuardConditionPossibleOnLefthandSideOfAssignment) {
+    this->performTestExecutionForCircuitLoadedFromJson(RELATIVE_PATH_TO_TEST_CASE_DATA_JSON_FILE, this->getNameOfCurrentlyExecutedTest());
+}
+
+TYPED_TEST_P(BaseSimulationTestFixture, OverlappingAccessOnQubitOfGuardConditionPossibleOnLefthandSideOfAssignment) {
+    this->performTestExecutionForCircuitLoadedFromJson(RELATIVE_PATH_TO_TEST_CASE_DATA_JSON_FILE, this->getNameOfCurrentlyExecutedTest());
+}
+
+TYPED_TEST_P(BaseSimulationTestFixture, AccessOnSameQubitOfGuardConditionPossibleOnRighthandSideOfAssignmentUsingPrefixAssignmentOperand) {
+    this->performTestExecutionForCircuitLoadedFromJson(RELATIVE_PATH_TO_TEST_CASE_DATA_JSON_FILE, this->getNameOfCurrentlyExecutedTest());
+}
+
+TYPED_TEST_P(BaseSimulationTestFixture, OverlappingAccessOnQubitOfGuardConditionPossibleOnRighthandSideOfAssignmentUsingPrefixAssignmentOperand) {
+    this->performTestExecutionForCircuitLoadedFromJson(RELATIVE_PATH_TO_TEST_CASE_DATA_JSON_FILE, this->getNameOfCurrentlyExecutedTest());
+}
+
 REGISTER_TYPED_TEST_SUITE_P(BaseSimulationTestFixture,
                             // BEGIN of tests for production UnaryExpression
                             LogicalNegationOfConstantZero,
@@ -359,7 +375,12 @@ REGISTER_TYPED_TEST_SUITE_P(BaseSimulationTestFixture,
                             IncrementBitOfValueOfDimensionOfVariable,
                             IncrementBitrangeOfValueOfDimensionOfVariableWithBitrangeStartSmallerThanEnd,
                             IncrementBitrangeOfValueOfDimensionOfVariableWithBitrangeStartLargerThanEnd,
-                            IncrementBitrangeOfValueOfDimensionOfVariableWithBitrangeStartEqualToEnd
+                            IncrementBitrangeOfValueOfDimensionOfVariableWithBitrangeStartEqualToEnd,
+
+                            AccessOnSameQubitOfGuardConditionPossibleOnLefthandSideOfAssignment,
+                            OverlappingAccessOnQubitOfGuardConditionPossibleOnLefthandSideOfAssignment,
+                            AccessOnSameQubitOfGuardConditionPossibleOnRighthandSideOfAssignmentUsingPrefixAssignmentOperand,
+                            OverlappingAccessOnQubitOfGuardConditionPossibleOnRighthandSideOfAssignmentUsingPrefixAssignmentOperand
                             // END of tests for production AssignStatement
 );
 


### PR DESCRIPTION
## Description

This PR introduces the following (potentially temporary) changes:
- The return value of all `addOperationsImplementingXGate(...)`, `registerControlQubitForPropagationInCurrentAndNestedScopes` and 'deregisterControlQubitFromPropagationInCurrentScope` functions of the `syrec::AnnotatableQuantumComputation` must now be handled by the caller to detect error cases as defined in the referenced issue. All calls in which the return value was not used were refactored.
- The qubit accessed in a VariableExpression used as the guard condition of an IfStatement is stored in an ancillary qubit so the former can be used as a target qubit in any statement of the two branches of the IfStatement. This change may be temporary but we refer there to the discussion in the referenced issue.
- The expected synthesis costs of the circuits used in the synthesis tests had to be updated.

Fixes #310 

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [X] The pull request only contains commits that are related to it.
- [X] I have added appropriate tests and documentation.
- [X] I have made sure that all CI jobs on GitHub pass.
- [X] The pull request introduces no new warnings and follows the project's style guidelines.
