### PR TITLE
✨Unification of search for main module between SyReC parser and synthesis algorithms

### DIFF
--- a/include/core/properties.hpp
+++ b/include/core/properties.hpp
@@ -56,7 +56,7 @@ namespace syrec {
          * @param key The key that is used in the search for a matching element.
          * @return Whether an entry for the key exists.
          */
-        [[maybe_unused]] bool containsKey(const std::string& key) const {
+        [[nodiscard]] bool containsKey(const std::string& key) const {
             return map.find(key) != map.cend();
         }
 

--- a/include/core/properties.hpp
+++ b/include/core/properties.hpp
@@ -101,6 +101,28 @@ namespace syrec {
         }
 
         /**
+         * Check whether an entry for a given key exists.
+         * @param key The key that is used in the search for a matching element.
+         * @return Whether an entry for the key exists.
+         */
+        [[maybe_unused]] bool containsKey(const key_type& key) const {
+            return map.find(key) != map.cend();
+        }
+
+        /**
+         * Remove an entry that matches a given key.
+         * @param key The key that is used in the search for a matching element.
+         * @return Whether an entry was removed.
+         */
+        [[maybe_unused]] bool remove(const key_type& key) {
+            if (auto matchingEntryForKey = map.find(key); matchingEntryForKey != map.cend()) {
+                map.erase(matchingEntryForKey);
+                return true;
+            }
+            return false;
+        }
+
+        /**
      * @brief Adds or modifies a value in the property map
      *
      * This methods sets the value located at key \p k to \p value.

--- a/include/core/properties.hpp
+++ b/include/core/properties.hpp
@@ -13,6 +13,7 @@
 #include <any>
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
 
 namespace syrec {
@@ -27,11 +28,14 @@ namespace syrec {
          * Fetch the value of the entry matching the given key.
          * @tparam T The expected type of the value of the entry in the map that must match exactly (i.e. not allowed be a derived type or assignable type of \p T).
          * @param key The key that is used in the search for a matching element.
-         * @return The value of the entry matching the given key.
+         * @return The value of the entry matching the given key casted to the template parameter \p T, otherwise std::nullopt.
          */
         template<typename T>
-        T get(const std::string& key) const {
-            return std::any_cast<T>(map.find(key)->second);
+        [[maybe_unused]] std::optional<T> get(const std::string& key) const {
+            if (auto matchingEntryForKey = map.find(key); matchingEntryForKey != map.cend()) {
+                return std::any_cast<T>(matchingEntryForKey->second);
+            }
+            return std::nullopt;
         }
 
         /**
@@ -43,11 +47,8 @@ namespace syrec {
          * @remarks No new entry in the internal lookup is created in case that no entry for the given key existed.
          */
         template<typename T>
-        T get(const std::string& key, const T& defaultValue) const {
-            if (map.find(key) == map.end()) {
-                return defaultValue;
-            }
-            return std::any_cast<T>(map.find(key)->second);
+        [[maybe_unused]] T get(const std::string& key, const T& defaultValue) const {
+            return get<T>(key).value_or(defaultValue);
         }
 
         /**
@@ -96,7 +97,7 @@ namespace syrec {
      * @return The value of the entry matching \p key if \p settings is a non-null properties object and a matching entry for \p key existed, otherwise \p defaultValue.
      */
     template<typename T>
-    T get(const Properties::ptr& settings, const std::string& key, const T& defaultValue) {
+    [[maybe_unused]] T get(const Properties::ptr& settings, const std::string& key, const T& defaultValue) {
         return settings != nullptr ? settings->get<T>(key, defaultValue) : defaultValue;
     }
 } // namespace syrec

--- a/include/core/properties.hpp
+++ b/include/core/properties.hpp
@@ -11,7 +11,6 @@
 #pragma once
 
 #include <any>
-#include <iostream>
 #include <map>
 #include <memory>
 #include <string>
@@ -19,85 +18,36 @@
 namespace syrec {
 
     /**
-   * @brief Property Map for storing settings and statistical information
-   *
-   * In this data structure settings and statistical data can be stored.
-   * The key to access data is always of type \p std::string and the value
-   * can be of any type. To be type-safe, the getter corresponding get
-   * functions have to be provided with a type.
-   */
+    * Property map for storing settings and statistical information
+    */
     struct Properties {
-        /**
-     * @brief Internal storage type used with the internal property map
-     */
-        using storage_type = std::map<std::string, std::any>;
-
-        /**
-     * @brief Value type of the property map, i.e. \p std::string
-     */
-        using value_type = storage_type::mapped_type;
-
-        /**
-     *
-     * There are pre-defined getter methods, which can be called with a
-     * type identifier for explicit casting.
-     */
-        using key_type = storage_type::key_type;
-
-        /**
-     * @brief Smart Pointer version of this class
-     *
-     * Inside the framework, always the Smart Pointer version is used.
-     * To have an easy access, there are special functions provided
-     * which take the smart pointer as parameter and check as well
-     * if it can be dereferenced.
-     *
-     * @sa get
-     * @sa set_error_message
-     */
         using ptr = std::shared_ptr<Properties>;
 
         /**
-     * @brief Standard constructor
-     *
-     * Creates the property map on base of the storage map
-     */
-        Properties() = default;
-
-        /**
-     * @brief Casted access to an existing element
-     *
-     * With \p T you can specify the type of the element. Note, that
-     * it has to be the original used type, e.g. there is a difference
-     * even between \p int and \p unsigned.
-     *
-     * The type is determined automatically using the set method.
-     *
-     * @param k Key to access the property map. Must exist.
-     * @return The value associated with key \p k casted to its original type \p T.
-     */
+         * Fetch the value of the entry matching the given key.
+         * @tparam T The expected type of the value of the entry in the map that must match exactly (i.e. not allowed be a derived type or assignable type of \p T).
+         * @param key The key that is used in the search for a matching element.
+         * @return The value of the entry matching the given key.
+         */
         template<typename T>
-        T get(const std::string& k) const {
-            return std::any_cast<T>(map.find(k)->second);
+        T get(const std::string& key) const {
+            return std::any_cast<T>(map.find(key)->second);
         }
 
         /**
-     * @brief Casted access to an existing element with fall-back option
-     *
-     * The same as get(const key_type& k), but if \p k does not exist,
-     * a default value is returned, which has to be of type \p T.
-     *
-     * @param k Key to access the property map. May not exist.
-     * @param default_value If \p k does not exist, this value is returned.
-     * @return The value associated with key \p k casted to its original type \p T. If the key \p k does not exist,
-     *         \p default_value is returned.
-     */
+         * Fetch the value of the entry matching the given key or return a default value.
+         * @tparam T The expected type of the value of the entry in the map that must match exactly (i.e. not allowed be a derived type or assignable type of \p T).
+         * @param key The key that is used in the search for a matching element.
+         * @param defaultValue The default value to return if no entry for the given key exists.
+         * @return The value of the entry matching the given key, otherwise \p defaultValue.
+         * @remarks No new entry in the internal lookup is created in case that no entry for the given key existed.
+         */
         template<typename T>
-        T get(const key_type& k, const T& defaultValue) const {
-            if (map.find(k) == map.end()) {
+        T get(const std::string& key, const T& defaultValue) const {
+            if (map.find(key) == map.end()) {
                 return defaultValue;
             }
-            return std::any_cast<T>(map.find(k)->second);
+            return std::any_cast<T>(map.find(key)->second);
         }
 
         /**
@@ -105,7 +55,7 @@ namespace syrec {
          * @param key The key that is used in the search for a matching element.
          * @return Whether an entry for the key exists.
          */
-        [[maybe_unused]] bool containsKey(const key_type& key) const {
+        [[maybe_unused]] bool containsKey(const std::string& key) const {
             return map.find(key) != map.cend();
         }
 
@@ -114,7 +64,7 @@ namespace syrec {
          * @param key The key that is used in the search for a matching element.
          * @return Whether an entry was removed.
          */
-        [[maybe_unused]] bool remove(const key_type& key) {
+        [[maybe_unused]] bool remove(const std::string& key) {
             if (auto matchingEntryForKey = map.find(key); matchingEntryForKey != map.cend()) {
                 map.erase(matchingEntryForKey);
                 return true;
@@ -123,52 +73,30 @@ namespace syrec {
         }
 
         /**
-     * @brief Adds or modifies a value in the property map
-     *
-     * This methods sets the value located at key \p k to \p value.
-     * If the key does not exist, it will be created.
-     * Be careful which type was used, especially with typed constants:
-     * @code
-     * properties p;
-     * p.set( "a unsigned number", 5u );
-     * p.get<unsigned>( "a unsigned number" ); // OK!
-     * p.get<int>( "a unsigned number" );      // FAIL!
-     *
-     * p.set( "a signed number", 5 );
-     * p.get<unsigned>( "a signed number" );   // FAIL!
-     * p.get<int>( "a signed number" );        // OK!
-     * @endcode
-     *
-     * @param k Key of the property
-     * @param value The new value of \p k. If \p k already existed, the type of \p value must not change.
-     */
+         * Add or update the value of an entry in the internal lookup
+         * @tparam T The expected type of the value of the entry in the internal lookup. The same type must be used in all overloads of the get(...) function when attempting to query the value of said entry.
+         * @param key The key with which the entry is identified in the internal lookup.
+         * @param value The value of the entry.
+         */
         template<typename T>
-        void set(const std::string& k, const T& value) {
-            map[k] = value;
+        void set(const std::string& key, const T& value) {
+            map[key] = value;
         }
 
     private:
-        storage_type map;
+        std::map<std::string, std::any> map;
     };
 
     /**
-   * @brief A helper method to access the get method on a properties smart pointer
-   *
-   * This method has basically two fall backs. If settings does not point to anything,
-   * it returns \p default_value, and otherwise it calls the get method on the
-   * pointee of the smart pointer with the \p default_value again, so in case the key \p k
-   * does not exists, the \p default_value is returned as well.
-   *
-   * @param settings A smart pointer to a properties instance or an empty smart pointer
-   * @param k Key of the property to be accessed
-   * @param default_value A default_value as fall back option in case the smart pointer
-   *                      is empty or the key does not exist.
-   *
-   * @return The value addressed by \p k or the \p default_value.
-   */
+     * Fetch the value of an entry in a properties object or return a default value if no such value exists.
+     * @tparam T The expected type of the value of the entry in the map that must match exactly (i.e. not allowed be a derived type or assignable type of \p T).
+     * @param settings The properties object that shall be queried.
+     * @param key The key that is used in the search for a matching element.
+     * @param defaultValue The default value to return in case no matching entry was found.
+     * @return The value of the entry matching \p key if \p settings is a non-null properties object and a matching entry for \p key existed, otherwise \p defaultValue.
+     */
     template<typename T>
-    T get(const Properties::ptr& settings, const Properties::key_type& k, const T& defaultValue) {
-        return settings ? settings->get<T>(k, defaultValue) : defaultValue;
+    T get(const Properties::ptr& settings, const std::string& key, const T& defaultValue) {
+        return settings != nullptr ? settings->get<T>(key, defaultValue) : defaultValue;
     }
-
 } // namespace syrec

--- a/include/core/syrec/parser/utils/custom_error_messages.hpp
+++ b/include/core/syrec/parser/utils/custom_error_messages.hpp
@@ -41,7 +41,8 @@ namespace syrec_parser {
         VariableBitwidthEqualToZero,
         NumberOfValuesOfDimensionEqualToZero,
         NoModuleMatchingUserDefinedProgramEntryPoint,
-        ReservedIdentifierPrefixUsed
+        ReservedIdentifierPrefixUsed,
+        InvalidUserDefinedProgramEntryPointModuleIdentifier
     };
 
     /// Get the identifier associated with a given semantic error
@@ -105,6 +106,8 @@ namespace syrec_parser {
                 return "SEM27";
             case SemanticError::ReservedIdentifierPrefixUsed:
                 return "SEM28";
+            case SemanticError::InvalidUserDefinedProgramEntryPointModuleIdentifier:
+                return "SEM29";
             default:
                 return "";
         }
@@ -172,6 +175,8 @@ namespace syrec_parser {
                 return "No module matching the user defined SyReC programs entry point identifier '{:s}'";
             case SemanticError::ReservedIdentifierPrefixUsed:
                 return "Identifier '{:s}' cannot start with '{:s}' since this prefix is reserved for internal use";
+            case SemanticError::InvalidUserDefinedProgramEntryPointModuleIdentifier:
+                return "User defined program entry point defined as module identifier '{:s}' was not valid!";
             default:
                 return "";
         }

--- a/src/algorithms/synthesis/syrec_synthesis.cpp
+++ b/src/algorithms/synthesis/syrec_synthesis.cpp
@@ -44,7 +44,7 @@ namespace {
      */
     using TimeStamp = std::chrono::time_point<std::chrono::steady_clock>;
 
-    [[nodiscard]] inline bool isMoreThanOneModuleNamedMainDeclared(const syrec::Module::vec& modulesToCheck) {
+    [[nodiscard]] bool isMoreThanOneModuleNamedMainDeclared(const syrec::Module::vec& modulesToCheck) {
         return std::count_if(modulesToCheck.cbegin(), modulesToCheck.cend(), [](const syrec::Module::ptr& moduleToCheck) { return moduleToCheck->name == "main"; }) > 1;
     }
 } // namespace
@@ -90,25 +90,23 @@ namespace syrec {
 
         const Module::vec& programModules = program.modules();
         if (programModules.empty()) {
-            std::cerr << "A SyReC program must consist of at least one module";
+            std::cerr << "A SyReC program must consist of at least one module\n";
             return false;
         }
 
         // Validation of optional defined main module identifier of synthesis settings
         const std::string&         defaultMainModuleIdentifier = "main";
         std::optional<std::string> expectedMainModuleIdentifier;
-        if (settings != nullptr) {
-            if (settings->containsKey(MAIN_MODULE_IDENTIFIER_CONFIG_KEY)) {
-                expectedMainModuleIdentifier = settings->get<std::string>(MAIN_MODULE_IDENTIFIER_CONFIG_KEY);
-                if (expectedMainModuleIdentifier.value().empty()) {
-                    std::cerr << "Expected main module identifier defined in synthesis settings must have a value";
-                    return false;
-                }
-                const std::regex expectedMainModuleIdentifierValidationRegex("^(_|[a-zA-Z])+\\w*");
-                if (!std::regex_match(*expectedMainModuleIdentifier, expectedMainModuleIdentifierValidationRegex)) {
-                    std::cerr << "Expected main module identifier defined in synthesis settings '" << *expectedMainModuleIdentifier << "' did not defined a valid identifier according to the SyReC grammar, check your inputs!";
-                    return false;
-                }
+        if (settings != nullptr && settings->get<std::string>(MAIN_MODULE_IDENTIFIER_CONFIG_KEY).has_value()) {
+            expectedMainModuleIdentifier = settings->get<std::string>(MAIN_MODULE_IDENTIFIER_CONFIG_KEY);
+            if (expectedMainModuleIdentifier.value().empty()) {
+                std::cerr << "Expected main module identifier defined in synthesis settings must have a value\n";
+                return false;
+            }
+            const std::regex expectedMainModuleIdentifierValidationRegex("^(_|[a-zA-Z])+\\w*");
+            if (!std::regex_match(*expectedMainModuleIdentifier, expectedMainModuleIdentifierValidationRegex)) {
+                std::cerr << "Expected main module identifier defined in synthesis settings '" << *expectedMainModuleIdentifier << "' did not defined a valid identifier according to the SyReC grammar, check your inputs!\n";
+                return false;
             }
         } else {
             if (program.findModule(defaultMainModuleIdentifier) != nullptr) {
@@ -125,12 +123,12 @@ namespace syrec {
         Module::ptr main;
         if (expectedMainModuleIdentifier.has_value()) {
             if (expectedMainModuleIdentifier.value() == defaultMainModuleIdentifier && isMoreThanOneModuleNamedMainDeclared(programModules)) {
-                std::cerr << "There can be at most one module named 'main'";
+                std::cerr << "There can be at most one module named 'main'\n";
                 return false;
             }
             const auto& lastModuleMatchingIdentifier = std::find_if(programModules.crbegin(), programModules.crend(), [&expectedMainModuleIdentifier](const Module::ptr& programModule) { return programModule->name == *expectedMainModuleIdentifier; });
             if (lastModuleMatchingIdentifier == programModules.crend()) {
-                std::cerr << "If the expected main module identifier is defined using the synthesis settings ('" << *expectedMainModuleIdentifier << "') then there must be at least one module matching the defined identifier";
+                std::cerr << "If the expected main module identifier is defined using the synthesis settings ('" << *expectedMainModuleIdentifier << "') then there must be at least one module matching the defined identifier\n";
                 return false;
             }
             main = *lastModuleMatchingIdentifier;
@@ -138,7 +136,7 @@ namespace syrec {
             main = program.findModule(defaultMainModuleIdentifier);
             if (main != nullptr) {
                 if (isMoreThanOneModuleNamedMainDeclared(programModules)) {
-                    std::cerr << "There can be at most one module named 'main'";
+                    std::cerr << "There can be at most one module named 'main'\n";
                     return false;
                 }
             } else {
@@ -162,11 +160,11 @@ namespace syrec {
 
         // create lines for global variables
         if (!synthesizer->addVariables(main->parameters)) {
-            std::cerr << "Failed to create qubits for parameters of main module of SyReC program";
+            std::cerr << "Failed to create qubits for parameters of main module of SyReC program\n";
             return false;
         }
         if (!synthesizer->addVariables(main->variables)) {
-            std::cerr << "Failed to create qubits for local variables of main module of SyReC program";
+            std::cerr << "Failed to create qubits for local variables of main module of SyReC program\n";
             return false;
         }
 
@@ -174,7 +172,7 @@ namespace syrec {
         const auto synthesisOfMainModuleOk = synthesizer->onModule(main);
         for (const auto& ancillaryQubit: synthesizer->annotatableQuantumComputation.getAddedPreliminaryAncillaryQubitIndices()) {
             if (!synthesizer->annotatableQuantumComputation.promotePreliminaryAncillaryQubitToDefinitiveAncillary(ancillaryQubit)) {
-                std::cerr << "Failed to mark qubit" << std::to_string(ancillaryQubit) << " as ancillary qubit";
+                std::cerr << "Failed to mark qubit" << std::to_string(ancillaryQubit) << " as ancillary qubit\n";
                 return false;
             }
         }
@@ -1237,7 +1235,7 @@ namespace syrec {
             const std::string_view&             parameterIdentifier                        = moduleParameters.at(i);
             const std::optional<Variable::ptr>& matchingParameterOrVariableOfCurrentModule = modules.top()->findParameterOrVariable(parameterIdentifier);
             if (!matchingParameterOrVariableOfCurrentModule.has_value() || matchingParameterOrVariableOfCurrentModule.value() == nullptr) {
-                std::cerr << "Failed to find matching parameter or variable of module " << modules.top()->name << " for parameter '" << parameterIdentifier << "' when setting references of parameters of " << (callStmt != nullptr ? "called" : "uncalled") << " module " << targetModule->name;
+                std::cerr << "Failed to find matching parameter or variable of module " << modules.top()->name << " for parameter '" << parameterIdentifier << "' when setting references of parameters of " << (callStmt != nullptr ? "called" : "uncalled") << " module " << targetModule->name << "\n";
                 return false;
             }
             const auto& moduleParameter = targetModule->parameters.at(i);
@@ -1285,9 +1283,9 @@ namespace syrec {
                 } else {
                     const auto offsetFromLastStmtToCurrentlyProcessedOneInUncalledModule = static_cast<std::size_t>(std::distance(statements.rend(), it));
                     if (callStmt != nullptr) {
-                        std::cerr << "Failed to create inverse of statement at index " << std::to_string(statements.size() - offsetFromLastStmtToCurrentlyProcessedOneInUncalledModule) << " in body of called module " << targetModule->name << "(CALL @ " << std::to_string(it->get()->lineNumber) << ")";
+                        std::cerr << "Failed to create inverse of statement at index " << std::to_string(statements.size() - offsetFromLastStmtToCurrentlyProcessedOneInUncalledModule) << " in body of called module " << targetModule->name << "(CALL @ " << std::to_string(it->get()->lineNumber) << ")\n";
                     } else {
-                        std::cerr << "Failed to create inverse of statement at index " << std::to_string(statements.size() - offsetFromLastStmtToCurrentlyProcessedOneInUncalledModule) << " in body of uncalled module " << targetModule->name << "(UNCALL @ " << std::to_string(it->get()->lineNumber) << ")";
+                        std::cerr << "Failed to create inverse of statement at index " << std::to_string(statements.size() - offsetFromLastStmtToCurrentlyProcessedOneInUncalledModule) << " in body of uncalled module " << targetModule->name << "(UNCALL @ " << std::to_string(it->get()->lineNumber) << ")\n";
                     }
                     synthesisOfModuleBodyOk = false;
                 }

--- a/src/algorithms/synthesis/syrec_synthesis.cpp
+++ b/src/algorithms/synthesis/syrec_synthesis.cpp
@@ -30,6 +30,7 @@
 #include <iterator>
 #include <memory>
 #include <optional>
+#include <regex>
 #include <stack>
 #include <string>
 #include <string_view>
@@ -42,6 +43,10 @@ namespace {
      * Prefer the usage of std::chrono::steady_clock instead of std::chrono::system_clock since the former cannot decrease (due to time zone changes, etc.) and is most suitable for measuring intervals according to (https://en.cppreference.com/w/cpp/chrono/steady_clock)
      */
     using TimeStamp = std::chrono::time_point<std::chrono::steady_clock>;
+
+    [[nodiscard]] inline bool isMoreThanOneModuleNamedMainDeclared(const syrec::Module::vec& modulesToCheck) {
+        return std::count_if(modulesToCheck.cbegin(), modulesToCheck.cend(), [](const syrec::Module::ptr& moduleToCheck) { return moduleToCheck->name == "main"; }) > 1;
+    }
 } // namespace
 
 namespace syrec {
@@ -83,26 +88,64 @@ namespace syrec {
             return false;
         }
 
-        // Settings parsing
-        const auto& expectedMainModuleIdentifier = settings != nullptr ? settings->get<std::string>(MAIN_MODULE_IDENTIFIER_CONFIG_KEY, "") : "";
+        const Module::vec& programModules = program.modules();
+        if (programModules.empty()) {
+            std::cerr << "A SyReC program must consist of at least one module";
+            return false;
+        }
+
+        // Validation of optional defined main module identifier of synthesis settings
+        const std::string&         defaultMainModuleIdentifier = "main";
+        std::optional<std::string> expectedMainModuleIdentifier;
+        if (settings != nullptr) {
+            if (settings->containsKey(MAIN_MODULE_IDENTIFIER_CONFIG_KEY)) {
+                expectedMainModuleIdentifier = settings->get<std::string>(MAIN_MODULE_IDENTIFIER_CONFIG_KEY);
+                if (expectedMainModuleIdentifier.value().empty()) {
+                    std::cerr << "Expected main module identifier defined in synthesis settings must have a value";
+                    return false;
+                }
+                const std::regex expectedMainModuleIdentifierValidationRegex("^(_|[a-zA-Z])+\\w*");
+                if (!std::regex_match(*expectedMainModuleIdentifier, expectedMainModuleIdentifierValidationRegex)) {
+                    std::cerr << "Expected main module identifier defined in synthesis settings '" << *expectedMainModuleIdentifier << "' did not defined a valid identifier according to the SyReC grammar, check your inputs!";
+                    return false;
+                }
+            }
+        } else {
+            if (program.findModule(defaultMainModuleIdentifier) != nullptr) {
+                expectedMainModuleIdentifier = defaultMainModuleIdentifier;
+            } else {
+                expectedMainModuleIdentifier = program.modules().back()->name;
+            }
+        }
+
         // Run-time measuring
         const TimeStamp simulationStartTime = std::chrono::steady_clock::now();
 
         // get the main module
         Module::ptr main;
-
-        if (!expectedMainModuleIdentifier.empty()) {
-            main = program.findModule(expectedMainModuleIdentifier);
-            if (!main) {
-                std::cerr << "Program has no module: " << expectedMainModuleIdentifier << "\n";
+        if (expectedMainModuleIdentifier.has_value()) {
+            if (expectedMainModuleIdentifier.value() == defaultMainModuleIdentifier && isMoreThanOneModuleNamedMainDeclared(programModules)) {
+                std::cerr << "There can be at most one module named 'main'";
                 return false;
             }
+            const auto& lastModuleMatchingIdentifier = std::find_if(programModules.crbegin(), programModules.crend(), [&expectedMainModuleIdentifier](const Module::ptr& programModule) { return programModule->name == *expectedMainModuleIdentifier; });
+            if (lastModuleMatchingIdentifier == programModules.crend()) {
+                std::cerr << "If the expected main module identifier is defined using the synthesis settings ('" << *expectedMainModuleIdentifier << "') then there must be at least one module matching the defined identifier";
+                return false;
+            }
+            main = *lastModuleMatchingIdentifier;
         } else {
-            main = program.findModule("main");
-            if (!main) {
-                main = program.modules().front();
+            main = program.findModule(defaultMainModuleIdentifier);
+            if (main != nullptr) {
+                if (isMoreThanOneModuleNamedMainDeclared(programModules)) {
+                    std::cerr << "There can be at most one module named 'main'";
+                    return false;
+                }
+            } else {
+                main = programModules.back();
             }
         }
+        assert(main != nullptr);
 
         // declare as top module
         synthesizer->setMainModule(main);

--- a/src/algorithms/synthesis/syrec_synthesis.cpp
+++ b/src/algorithms/synthesis/syrec_synthesis.cpp
@@ -44,8 +44,8 @@ namespace {
      */
     using TimeStamp = std::chrono::time_point<std::chrono::steady_clock>;
 
-    [[nodiscard]] bool isMoreThanOneModuleNamedMainDeclared(const syrec::Module::vec& modulesToCheck) {
-        return std::count_if(modulesToCheck.cbegin(), modulesToCheck.cend(), [](const syrec::Module::ptr& moduleToCheck) { return moduleToCheck->name == "main"; }) > 1;
+    [[nodiscard]] bool isMoreThanOneModuleMatchingIdentifierDeclared(const syrec::Module::vec& modulesToCheck, const std::string_view& moduleIdentifierToFind) {
+        return std::count_if(modulesToCheck.cbegin(), modulesToCheck.cend(), [moduleIdentifierToFind](const syrec::Module::ptr& moduleToCheck) { return moduleToCheck->name == moduleIdentifierToFind; }) > 1;
     }
 } // namespace
 
@@ -122,8 +122,8 @@ namespace syrec {
         // get the main module
         Module::ptr main;
         if (expectedMainModuleIdentifier.has_value()) {
-            if (expectedMainModuleIdentifier.value() == defaultMainModuleIdentifier && isMoreThanOneModuleNamedMainDeclared(programModules)) {
-                std::cerr << "There can be at most one module named 'main'\n";
+            if (isMoreThanOneModuleMatchingIdentifierDeclared(programModules, *expectedMainModuleIdentifier)) {
+                std::cerr << "There can be at most one module named '" << *expectedMainModuleIdentifier << "' that shall be used as the entry point of the SyReC program\n";
                 return false;
             }
             const auto& lastModuleMatchingIdentifier = std::find_if(programModules.crbegin(), programModules.crend(), [&expectedMainModuleIdentifier](const Module::ptr& programModule) { return programModule->name == *expectedMainModuleIdentifier; });
@@ -135,7 +135,7 @@ namespace syrec {
         } else {
             main = program.findModule(defaultMainModuleIdentifier);
             if (main != nullptr) {
-                if (isMoreThanOneModuleNamedMainDeclared(programModules)) {
+                if (isMoreThanOneModuleMatchingIdentifierDeclared(programModules, defaultMainModuleIdentifier)) {
                     std::cerr << "There can be at most one module named 'main'\n";
                     return false;
                 }

--- a/src/core/syrec/parser/components/custom_module_visitor.cpp
+++ b/src/core/syrec/parser/components/custom_module_visitor.cpp
@@ -27,6 +27,7 @@
 #include <cstddef>
 #include <memory>
 #include <optional>
+#include <regex>
 #include <string>
 #include <variant>
 #include <vector>
@@ -56,12 +57,19 @@ std::optional<std::shared_ptr<syrec::Program>> CustomModuleVisitor::visitProgram
 
     std::string                          programEntryPointModuleIdentifier;
     std::shared_ptr<const syrec::Module> definedMainModule = nullptr;
-    if (const std::string& userDefinedProgramEntryPointModuleIdentifier = parserConfiguration.optionalProgramEntryPointModuleIdentifier.value_or(""); !userDefinedProgramEntryPointModuleIdentifier.empty()) {
-        const syrec::Module::vec modulesMatchingIdentifier = symbolTable->getModulesByName(userDefinedProgramEntryPointModuleIdentifier);
-        if (modulesMatchingIdentifier.empty()) {
-            recordSemanticError<SemanticError::NoModuleMatchingUserDefinedProgramEntryPoint>(Message::Position(0, 0), userDefinedProgramEntryPointModuleIdentifier);
+
+    if (parserConfiguration.optionalProgramEntryPointModuleIdentifier.has_value()) {
+        const std::string userDefinedProgramEntryPointModuleIdentifier = parserConfiguration.optionalProgramEntryPointModuleIdentifier.value();
+        const std::regex  mainModuleIdentifierValidationRegex("^(_|[a-zA-Z])+\\w*");
+        if (!std::regex_match(userDefinedProgramEntryPointModuleIdentifier, mainModuleIdentifierValidationRegex)) {
+            recordSemanticError<SemanticError::InvalidUserDefinedProgramEntryPointModuleIdentifier>(Message::Position(0, 0), userDefinedProgramEntryPointModuleIdentifier);
         } else {
-            definedMainModule = modulesMatchingIdentifier.front();
+            const syrec::Module::vec modulesMatchingIdentifier = symbolTable->getModulesByName(userDefinedProgramEntryPointModuleIdentifier);
+            if (modulesMatchingIdentifier.empty()) {
+                recordSemanticError<SemanticError::NoModuleMatchingUserDefinedProgramEntryPoint>(Message::Position(0, 0), userDefinedProgramEntryPointModuleIdentifier);
+            } else {
+                definedMainModule = modulesMatchingIdentifier.back();
+            }
         }
     } else {
         if (const syrec::Module::vec modulesMatchingIdentifier = symbolTable->getModulesByName("main"); !modulesMatchingIdentifier.empty()) {

--- a/src/core/syrec/parser/components/custom_module_visitor.cpp
+++ b/src/core/syrec/parser/components/custom_module_visitor.cpp
@@ -59,14 +59,16 @@ std::optional<std::shared_ptr<syrec::Program>> CustomModuleVisitor::visitProgram
     std::shared_ptr<const syrec::Module> definedMainModule = nullptr;
 
     if (parserConfiguration.optionalProgramEntryPointModuleIdentifier.has_value()) {
+        const auto userDefinedMainModuleIdentifierSemanticErrorPosition = Message::Position(0, 0);
+
         const std::string userDefinedProgramEntryPointModuleIdentifier = parserConfiguration.optionalProgramEntryPointModuleIdentifier.value();
         const std::regex  mainModuleIdentifierValidationRegex("^(_|[a-zA-Z])+\\w*");
         if (!std::regex_match(userDefinedProgramEntryPointModuleIdentifier, mainModuleIdentifierValidationRegex)) {
-            recordSemanticError<SemanticError::InvalidUserDefinedProgramEntryPointModuleIdentifier>(Message::Position(0, 0), userDefinedProgramEntryPointModuleIdentifier);
+            recordSemanticError<SemanticError::InvalidUserDefinedProgramEntryPointModuleIdentifier>(userDefinedMainModuleIdentifierSemanticErrorPosition, userDefinedProgramEntryPointModuleIdentifier);
         } else {
             const syrec::Module::vec modulesMatchingIdentifier = symbolTable->getModulesByName(userDefinedProgramEntryPointModuleIdentifier);
             if (modulesMatchingIdentifier.empty()) {
-                recordSemanticError<SemanticError::NoModuleMatchingUserDefinedProgramEntryPoint>(Message::Position(0, 0), userDefinedProgramEntryPointModuleIdentifier);
+                recordSemanticError<SemanticError::NoModuleMatchingUserDefinedProgramEntryPoint>(userDefinedMainModuleIdentifierSemanticErrorPosition, userDefinedProgramEntryPointModuleIdentifier);
             } else {
                 definedMainModule = modulesMatchingIdentifier.back();
             }

--- a/src/mqt/syrec/syrec_editor.py
+++ b/src/mqt/syrec/syrec_editor.py
@@ -969,7 +969,7 @@ class SynthesisSettingsUpdater(QtWidgets.QDialog):  # type: ignore[misc]
         self.expected_main_module_identifier_textbox.setPlaceholderText(
             "Leave blank if last declared module of SyReC program should be used as main module..."
         )
-        module_identifier_regular_expr = QtCore.QRegularExpression(R"(^$|^\w+\w*$)")
+        module_identifier_regular_expr = QtCore.QRegularExpression(R"(^($|^(_|[a-zA-Z])+\w*))")
         module_identifier_validator = QtGui.QRegularExpressionValidator(module_identifier_regular_expr, self)
         self.expected_main_module_identifier_textbox.setValidator(module_identifier_validator)
 
@@ -1007,11 +1007,13 @@ class SynthesisSettingsUpdater(QtWidgets.QDialog):  # type: ignore[misc]
     def save_settings(self) -> QtWidgets.QDialog.DialogCode:
         if self.synthesis_settings is not None:
             if self.expected_main_module_identifier_textbox.hasAcceptableInput():
-                self.synthesis_settings.set_string(
-                    syrec.SYNTHESIS_CONFIG_KEY_MAIN_MODULE_IDENTIFIER,
-                    self.expected_main_module_identifier_textbox.text(),
-                )
-
+                user_defined_main_module_identifier: str = self.expected_main_module_identifier_textbox.text()
+                if not user_defined_main_module_identifier:
+                    self.synthesis_settings.remove(syrec.SYNTHESIS_CONFIG_KEY_MAIN_MODULE_IDENTIFIER)
+                else:
+                    self.synthesis_settings.set_string(
+                        syrec.SYNTHESIS_CONFIG_KEY_MAIN_MODULE_IDENTIFIER, user_defined_main_module_identifier
+                    )
             self.synthesis_settings.set_bool(
                 syrec.SYNTHESIS_CONFIG_KEY_GENERATE_INLINE_DEBUG_INFORMATION,
                 self.generate_inlined_qubit_debug_information_checkbox.isChecked(),

--- a/src/python/bindings.cpp
+++ b/src/python/bindings.cpp
@@ -82,7 +82,9 @@ PYBIND11_MODULE(pysyrec, m) {
             .def("set_double", &Properties::set<double>)
             .def("get_string", py::overload_cast<const std::string&>(&Properties::get<std::string>, py::const_))
             .def("get_double", py::overload_cast<const std::string&>(&Properties::get<double>, py::const_))
-            .def("get_bool", py::overload_cast<const std::string&>(&Properties::get<bool>, py::const_));
+            .def("get_bool", py::overload_cast<const std::string&>(&Properties::get<bool>, py::const_))
+            .def("contains", &Properties::containsKey, "key"_a, "Determine whether a matching entry for the given key exists")
+            .def("remove", &Properties::remove, "key"_a, "Removes the entry matching the given key");
 
     py::enum_<utils::IntegerConstantTruncationOperation>(m, "integer_constant_truncation_operation")
             .value("modulo", utils::IntegerConstantTruncationOperation::Modulo, "Use the modulo operation for the truncation of constant values")

--- a/test/unittests/simulation/data/test_synthesis_of_basic_operations.json
+++ b/test/unittests/simulation/data/test_synthesis_of_basic_operations.json
@@ -1,4 +1,151 @@
 {
+  "OmittingUserDefinedMainModuleIdentifierInSynthesisSettingsChoosesModuleWithMainIdentiferAsMainModule": {
+    "inputCircuit": "module incr(inout a(2)) ++= a module decr(inout a(2)) --= a module main(inout a(2)) a ^= 1",
+    "simulationRuns": [
+      {
+        "in": "00",
+        "out": "10"
+      },
+      {
+        "in": "10",
+        "out": "00"
+      },
+      {
+        "in": "01",
+        "out": "11"
+      },
+      {
+        "in": "11",
+        "out": "01"
+      }
+    ]
+  },
+  "OmittingUserDefinedMainModuleIdentifierInSynthesisSettingsChoosesLastDefinedModuleAsMainModuleIfNoModuleWithIdentifierMainExists": {
+    "inputCircuit": "module incr(inout a(2)) ++= a module decr(inout a(2)) --= a module xor(inout a(2)) a ^= 1",
+    "simulationRuns": [
+      {
+        "in": "00",
+        "out": "10"
+      },
+      {
+        "in": "10",
+        "out": "00"
+      },
+      {
+        "in": "01",
+        "out": "11"
+      },
+      {
+        "in": "11",
+        "out": "01"
+      }
+    ]
+  },
+  "OmittingUserDefinedMainModuleIdentifierInSynthesisSettingsChoosesLastDefinedModuleAsMainModuleIfNoModuleWithIdentifierMatchingMainExactlyExists": {
+    "inputCircuit": "module main_incr(inout a(2)) ++= a module decr_main(inout a(2)) --= a module MAIN(inout a(2)) ~= a module xor(inout a(2)) a ^= 1",
+    "simulationRuns": [
+      {
+        "in": "00",
+        "out": "10"
+      },
+      {
+        "in": "10",
+        "out": "00"
+      },
+      {
+        "in": "01",
+        "out": "11"
+      },
+      {
+        "in": "11",
+        "out": "01"
+      }
+    ]
+  },
+
+  "OmittingUserDefinedMainModuleIdentifierInSynthesisSettingsChoosesLastDefinedModuleAsMainModuleIfNoModuleWithIdentifierMatchingMainInSameCasingExists": {
+    "inputCircuit": "module incr(inout a(2)) ++= a module MAIN(inout a(2)) --= a module main(inout a(2)) call incr(a)",
+    "simulationRuns": [
+      {
+        "in": "00",
+        "out": "10"
+      },
+      {
+        "in": "10",
+        "out": "01"
+      },
+      {
+        "in": "01",
+        "out": "11"
+      },
+      {
+        "in": "11",
+        "out": "00"
+      }
+    ]
+  },
+
+  "UserDefinedMainModuleIdentifierInSynthesisSettingsChoosesMatchingModuleInsteadOfModuleWithIdentifierMain": {
+    "inputCircuit": "module incr(inout a(2)) ++= a module main(inout a(2)) --= a",
+    "simulationRuns": [
+      {
+        "in": "00",
+        "out": "10"
+      },
+      {
+        "in": "10",
+        "out": "01"
+      },
+      {
+        "in": "01",
+        "out": "11"
+      },
+      {
+        "in": "11",
+        "out": "00"
+      }
+    ]
+  },
+  "UserDefinedMainModuleIdentifierInSynthesisSettingsOnlyPartiallyMatchingModuleWithFullMatchFoundSelectsLatterAsModuleModule": {
+    "inputCircuit": "module incr_4(inout a(4)) --= a module twoQubit_incr(inout a(2)) --= a module main(inout a(2)) --= a module incr(inout a(2)) ++= a",
+    "simulationRuns": [
+      {
+        "in": "00",
+        "out": "10"
+      },
+      {
+        "in": "10",
+        "out": "01"
+      },
+      {
+        "in": "01",
+        "out": "11"
+      },
+      {
+        "in": "11",
+        "out": "00"
+      }
+    ]
+  },
+  "UserDefinedMainModuleIdentifierInSynthesisSettingsAllowedToMatchOverloadedModuleIdentifierWithLastDefinedModuleSelectedAsMainModule": {
+    "inputCircuit": "module incr(inout a(1)) ++= a module incr(inout a(2)) ++= a.1 module incr(inout a(3)) ++= a.2",
+    "simulationRuns": [
+      {
+        "in": "000",
+        "out": "001"
+      }
+    ]
+  },
+  "UserDefinedModuleIdentifierInSynthesisSettingsOnlyMatchingModulesWithSameIdentifierCharacterCasing": {
+    "inputCircuit": "module incr(inout a(1)) ++= a module INCR(inout a(2)) ++= a.1 module incr(inout a(3)) ++= a.2",
+    "simulationRuns": [
+      {
+        "in": "00",
+        "out": "01"
+      }
+    ]
+  },
+
   "LogicalNegationOfConstantZero": {
     "inputCircuit": "module main(out a(1)) a ^= !0",
     "simulationRuns": [

--- a/test/unittests/simulation/data/test_synthesis_of_basic_operations.json
+++ b/test/unittests/simulation/data/test_synthesis_of_basic_operations.json
@@ -127,15 +127,6 @@
       }
     ]
   },
-  "UserDefinedMainModuleIdentifierInSynthesisSettingsAllowedToMatchOverloadedModuleIdentifierWithLastDefinedModuleSelectedAsMainModule": {
-    "inputCircuit": "module incr(inout a(1)) ++= a module incr(inout a(2)) ++= a.1 module incr(inout a(3)) ++= a.2",
-    "simulationRuns": [
-      {
-        "in": "000",
-        "out": "001"
-      }
-    ]
-  },
   "UserDefinedModuleIdentifierInSynthesisSettingsOnlyMatchingModulesWithSameIdentifierCharacterCasing": {
     "inputCircuit": "module incr(inout a(1)) ++= a module INCR(inout a(2)) ++= a.1 module incr(inout a(3)) ++= a.2",
     "simulationRuns": [

--- a/test/unittests/simulation/test_synthesis_basic_operations.cpp
+++ b/test/unittests/simulation/test_synthesis_basic_operations.cpp
@@ -93,11 +93,12 @@ TYPED_TEST_P(BaseSimulationTestFixture, UserDefinedMainModuleIdentifierInSynthes
     this->performTestExecutionForCircuitLoadedFromJson(RELATIVE_PATH_TO_TEST_CASE_DATA_JSON_FILE, this->getNameOfCurrentlyExecutedTest(), synthesisSettings);
 }
 
-TYPED_TEST_P(BaseSimulationTestFixture, UserDefinedMainModuleIdentifierInSynthesisSettingsAllowedToMatchOverloadedModuleIdentifierWithLastDefinedModuleSelectedAsMainModule) {
+TYPED_TEST_P(BaseSimulationTestFixture, UserDefinedMainModuleIdentifierInSynthesisSettingsMatchingMultipleModulesCausesError) {
     auto synthesisSettings = std::make_shared<syrec::Properties>();
     synthesisSettings->set<std::string>(syrec::SyrecSynthesis::MAIN_MODULE_IDENTIFIER_CONFIG_KEY, "incr");
 
-    this->performTestExecutionForCircuitLoadedFromJson(RELATIVE_PATH_TO_TEST_CASE_DATA_JSON_FILE, this->getNameOfCurrentlyExecutedTest(), synthesisSettings);
+    constexpr std::string_view stringifiedCircuitToParseAndSynthesis = "module incr(inout a(1)) ++= a module incr(inout a(2)) ++= a.1 module incr(inout a(3)) ++= a.2";
+    this->performTestExecutionExpectingSynthesisFailureForCircuitLoadedFromString(stringifiedCircuitToParseAndSynthesis, synthesisSettings);
 }
 
 TYPED_TEST_P(BaseSimulationTestFixture, UserDefinedModuleIdentifierInSynthesisSettingsOnlyMatchingModulesWithSameIdentifierCharacterCasing) {
@@ -629,7 +630,7 @@ REGISTER_TYPED_TEST_SUITE_P(BaseSimulationTestFixture,
                             UserDefinedMainModuleIdentifierInSynthesisSettingsBeingEmptyCausesError,
                             UserDefinedMainModuleIdentifierInSynthesisSettingsOnlyPartiallyMatchingModuleWithNoFullMatchFoundCausesError,
                             UserDefinedMainModuleIdentifierInSynthesisSettingsOnlyPartiallyMatchingModuleWithFullMatchFoundSelectsLatterAsModuleModule,
-                            UserDefinedMainModuleIdentifierInSynthesisSettingsAllowedToMatchOverloadedModuleIdentifierWithLastDefinedModuleSelectedAsMainModule,
+                            UserDefinedMainModuleIdentifierInSynthesisSettingsMatchingMultipleModulesCausesError,
                             UserDefinedModuleIdentifierInSynthesisSettingsOnlyMatchingModulesWithSameIdentifierCharacterCasing,
                             // END of tests of synthesis settings features
 

--- a/test/unittests/simulation/test_synthesis_basic_operations.cpp
+++ b/test/unittests/simulation/test_synthesis_basic_operations.cpp
@@ -10,14 +10,102 @@
 
 #include "algorithms/synthesis/syrec_cost_aware_synthesis.hpp"
 #include "algorithms/synthesis/syrec_line_aware_synthesis.hpp"
+#include "algorithms/synthesis/syrec_synthesis.hpp"
 #include "base_simulation_test_fixture.hpp"
+#include "core/properties.hpp"
 
 #include <gtest/gtest.h>
+#include <memory>
 #include <string>
+#include <string_view>
 
 const std::string RELATIVE_PATH_TO_TEST_CASE_DATA_JSON_FILE = "./unittests/simulation/data/test_synthesis_of_basic_operations.json";
 
 TYPED_TEST_SUITE_P(BaseSimulationTestFixture);
+
+TYPED_TEST_P(BaseSimulationTestFixture, OmittingUserDefinedMainModuleIdentifierInSynthesisSettingsChoosesModuleWithMainIdentiferAsMainModule) {
+    this->performTestExecutionForCircuitLoadedFromJson(RELATIVE_PATH_TO_TEST_CASE_DATA_JSON_FILE, this->getNameOfCurrentlyExecutedTest());
+}
+
+TYPED_TEST_P(BaseSimulationTestFixture, OmittingUserDefinedMainModuleIdentifierInSynthesisSettingsChoosesLastDefinedModuleAsMainModuleIfNoModuleWithIdentifierMainExists) {
+    this->performTestExecutionForCircuitLoadedFromJson(RELATIVE_PATH_TO_TEST_CASE_DATA_JSON_FILE, this->getNameOfCurrentlyExecutedTest());
+}
+
+TYPED_TEST_P(BaseSimulationTestFixture, OmittingUserDefinedMainModuleIdentifierInSynthesisSettingsChoosesLastDefinedModuleAsMainModuleIfNoModuleWithIdentifierMatchingMainExactlyExists) {
+    this->performTestExecutionForCircuitLoadedFromJson(RELATIVE_PATH_TO_TEST_CASE_DATA_JSON_FILE, this->getNameOfCurrentlyExecutedTest());
+}
+
+TYPED_TEST_P(BaseSimulationTestFixture, OmittingUserDefinedMainModuleIdentifierInSynthesisSettingsChoosesLastDefinedModuleAsMainModuleIfNoModuleWithIdentifierMatchingMainInSameCasingExists) {
+    this->performTestExecutionForCircuitLoadedFromJson(RELATIVE_PATH_TO_TEST_CASE_DATA_JSON_FILE, this->getNameOfCurrentlyExecutedTest());
+}
+
+TYPED_TEST_P(BaseSimulationTestFixture, UserDefinedMainModuleIdentifierInSynthesisSettingsNotValidCausesError) {
+    auto synthesisSettings = std::make_shared<syrec::Properties>();
+    synthesisSettings->set<std::string>(syrec::SyrecSynthesis::MAIN_MODULE_IDENTIFIER_CONFIG_KEY, "2_main");
+
+    constexpr std::string_view stringifiedCircuitToParseAndSynthesis = "module main(inout a(4)) ++= a";
+    this->performTestExecutionExpectingSynthesisFailureForCircuitLoadedFromString(stringifiedCircuitToParseAndSynthesis, synthesisSettings);
+}
+
+TYPED_TEST_P(BaseSimulationTestFixture, UserDefinedMainModuleIdentifierInSynthesisSettingsChoosesMatchingModuleInsteadOfModuleWithIdentifierMain) {
+    auto synthesisSettings = std::make_shared<syrec::Properties>();
+    synthesisSettings->set<std::string>(syrec::SyrecSynthesis::MAIN_MODULE_IDENTIFIER_CONFIG_KEY, "incr");
+
+    this->performTestExecutionForCircuitLoadedFromJson(RELATIVE_PATH_TO_TEST_CASE_DATA_JSON_FILE, this->getNameOfCurrentlyExecutedTest(), synthesisSettings);
+}
+
+TYPED_TEST_P(BaseSimulationTestFixture, UserDefinedMainModuleIdentifierInSynthesisSettingsNotMatchingAnyModuleAndModuleWithIdentifierMainExistingCausesError) {
+    auto synthesisSettings = std::make_shared<syrec::Properties>();
+    synthesisSettings->set<std::string>(syrec::SyrecSynthesis::MAIN_MODULE_IDENTIFIER_CONFIG_KEY, "a");
+
+    constexpr std::string_view stringifiedCircuitToParseAndSynthesis = "module decr(inout a(4)) --= a module sub(inout a(4), inout b(4)) a -= b module main(inout a(4), inout b(4)) call decr(a); call sub(a, b)";
+    this->performTestExecutionExpectingSynthesisFailureForCircuitLoadedFromString(stringifiedCircuitToParseAndSynthesis, synthesisSettings);
+}
+
+TYPED_TEST_P(BaseSimulationTestFixture, UserDefinedMainModuleIdentifierInSynthesisSettingsNotMatchingAnyModuleAndModuleWithIdentifierMainNotExistingCausesError) {
+    auto synthesisSettings = std::make_shared<syrec::Properties>();
+    synthesisSettings->set<std::string>(syrec::SyrecSynthesis::MAIN_MODULE_IDENTIFIER_CONFIG_KEY, "add");
+
+    constexpr std::string_view stringifiedCircuitToParseAndSynthesis = "module decr(inout a(4)) --= a module sub(inout a(4), inout b(4)) a -= b";
+    this->performTestExecutionExpectingSynthesisFailureForCircuitLoadedFromString(stringifiedCircuitToParseAndSynthesis, synthesisSettings);
+}
+
+TYPED_TEST_P(BaseSimulationTestFixture, UserDefinedMainModuleIdentifierInSynthesisSettingsBeingEmptyCausesError) {
+    auto synthesisSettings = std::make_shared<syrec::Properties>();
+    synthesisSettings->set<std::string>(syrec::SyrecSynthesis::MAIN_MODULE_IDENTIFIER_CONFIG_KEY, "");
+
+    constexpr std::string_view stringifiedCircuitToParseAndSynthesis = "module main(inout a(4)) ++= a";
+    this->performTestExecutionExpectingSynthesisFailureForCircuitLoadedFromString(stringifiedCircuitToParseAndSynthesis, synthesisSettings);
+}
+
+TYPED_TEST_P(BaseSimulationTestFixture, UserDefinedMainModuleIdentifierInSynthesisSettingsOnlyPartiallyMatchingModuleWithNoFullMatchFoundCausesError) {
+    auto synthesisSettings = std::make_shared<syrec::Properties>();
+    synthesisSettings->set<std::string>(syrec::SyrecSynthesis::MAIN_MODULE_IDENTIFIER_CONFIG_KEY, "add");
+
+    constexpr std::string_view stringifiedCircuitToParseAndSynthesis = "module add_4(inout a(4), inout b(4)) a += b module twoQubit_add_2(inout a(2), inout b(2)) a += b module twoQubit_add(inout a(2), inout b(2)) a += b";
+    this->performTestExecutionExpectingSynthesisFailureForCircuitLoadedFromString(stringifiedCircuitToParseAndSynthesis, synthesisSettings);
+}
+
+TYPED_TEST_P(BaseSimulationTestFixture, UserDefinedMainModuleIdentifierInSynthesisSettingsOnlyPartiallyMatchingModuleWithFullMatchFoundSelectsLatterAsModuleModule) {
+    auto synthesisSettings = std::make_shared<syrec::Properties>();
+    synthesisSettings->set<std::string>(syrec::SyrecSynthesis::MAIN_MODULE_IDENTIFIER_CONFIG_KEY, "incr");
+
+    this->performTestExecutionForCircuitLoadedFromJson(RELATIVE_PATH_TO_TEST_CASE_DATA_JSON_FILE, this->getNameOfCurrentlyExecutedTest(), synthesisSettings);
+}
+
+TYPED_TEST_P(BaseSimulationTestFixture, UserDefinedMainModuleIdentifierInSynthesisSettingsAllowedToMatchOverloadedModuleIdentifierWithLastDefinedModuleSelectedAsMainModule) {
+    auto synthesisSettings = std::make_shared<syrec::Properties>();
+    synthesisSettings->set<std::string>(syrec::SyrecSynthesis::MAIN_MODULE_IDENTIFIER_CONFIG_KEY, "incr");
+
+    this->performTestExecutionForCircuitLoadedFromJson(RELATIVE_PATH_TO_TEST_CASE_DATA_JSON_FILE, this->getNameOfCurrentlyExecutedTest(), synthesisSettings);
+}
+
+TYPED_TEST_P(BaseSimulationTestFixture, UserDefinedModuleIdentifierInSynthesisSettingsOnlyMatchingModulesWithSameIdentifierCharacterCasing) {
+    auto synthesisSettings = std::make_shared<syrec::Properties>();
+    synthesisSettings->set<std::string>(syrec::SyrecSynthesis::MAIN_MODULE_IDENTIFIER_CONFIG_KEY, "INCR");
+
+    this->performTestExecutionForCircuitLoadedFromJson(RELATIVE_PATH_TO_TEST_CASE_DATA_JSON_FILE, this->getNameOfCurrentlyExecutedTest(), synthesisSettings);
+}
 
 // BEGIN of tests for production UnaryExpression
 TYPED_TEST_P(BaseSimulationTestFixture, LogicalNegationOfConstantZero) {
@@ -529,6 +617,22 @@ TYPED_TEST_P(BaseSimulationTestFixture, InverseOfMultipleStatementsInUncalledMod
 // END of tests for production UncallStatement
 
 REGISTER_TYPED_TEST_SUITE_P(BaseSimulationTestFixture,
+                            // BEGIN of tests of synthesis settings features
+                            OmittingUserDefinedMainModuleIdentifierInSynthesisSettingsChoosesModuleWithMainIdentiferAsMainModule,
+                            OmittingUserDefinedMainModuleIdentifierInSynthesisSettingsChoosesLastDefinedModuleAsMainModuleIfNoModuleWithIdentifierMainExists,
+                            OmittingUserDefinedMainModuleIdentifierInSynthesisSettingsChoosesLastDefinedModuleAsMainModuleIfNoModuleWithIdentifierMatchingMainExactlyExists,
+                            OmittingUserDefinedMainModuleIdentifierInSynthesisSettingsChoosesLastDefinedModuleAsMainModuleIfNoModuleWithIdentifierMatchingMainInSameCasingExists,
+                            UserDefinedMainModuleIdentifierInSynthesisSettingsNotValidCausesError,
+                            UserDefinedMainModuleIdentifierInSynthesisSettingsChoosesMatchingModuleInsteadOfModuleWithIdentifierMain,
+                            UserDefinedMainModuleIdentifierInSynthesisSettingsNotMatchingAnyModuleAndModuleWithIdentifierMainExistingCausesError,
+                            UserDefinedMainModuleIdentifierInSynthesisSettingsNotMatchingAnyModuleAndModuleWithIdentifierMainNotExistingCausesError,
+                            UserDefinedMainModuleIdentifierInSynthesisSettingsBeingEmptyCausesError,
+                            UserDefinedMainModuleIdentifierInSynthesisSettingsOnlyPartiallyMatchingModuleWithNoFullMatchFoundCausesError,
+                            UserDefinedMainModuleIdentifierInSynthesisSettingsOnlyPartiallyMatchingModuleWithFullMatchFoundSelectsLatterAsModuleModule,
+                            UserDefinedMainModuleIdentifierInSynthesisSettingsAllowedToMatchOverloadedModuleIdentifierWithLastDefinedModuleSelectedAsMainModule,
+                            UserDefinedModuleIdentifierInSynthesisSettingsOnlyMatchingModulesWithSameIdentifierCharacterCasing,
+                            // END of tests of synthesis settings features
+
                             // BEGIN of tests for production UnaryExpression
                             LogicalNegationOfConstantZero,
                             LogicalNegationOfConstantOne,

--- a/test/unittests/syrec/parser/data/error/test_production_module_errors.cpp
+++ b/test/unittests/syrec/parser/data/error/test_production_module_errors.cpp
@@ -107,6 +107,24 @@ TEST_F(SyrecParserErrorTestsFixture, NoModuleMatchingUserDefinedExpectedMainModu
     performTestExecution("module userMain(in a[2](16)) skip module main(out b[1](16)) skip", parserConfiguration);
 }
 
+TEST_F(SyrecParserErrorTestsFixture, UserDefinedExpectedMainModuleIdentifierBeingInvalidCausesError) {
+    const std::string          userDefinedExpectedMainModuleIdentifier = "2_invalidIdentifier";
+    syrec::ReadProgramSettings parserConfiguration;
+    parserConfiguration.optionalProgramEntryPointModuleIdentifier = userDefinedExpectedMainModuleIdentifier;
+
+    buildAndRecordExpectedSemanticError<SemanticError::InvalidUserDefinedProgramEntryPointModuleIdentifier>(Message::Position(0, 0), userDefinedExpectedMainModuleIdentifier);
+    performTestExecution("module main(out b[1](16)) skip", parserConfiguration);
+}
+
+TEST_F(SyrecParserErrorTestsFixture, EmptyUserDefinedExpectedMainModuleIdentifierCausesError) {
+    const std::string          userDefinedExpectedMainModuleIdentifier;
+    syrec::ReadProgramSettings parserConfiguration;
+    parserConfiguration.optionalProgramEntryPointModuleIdentifier = userDefinedExpectedMainModuleIdentifier;
+
+    buildAndRecordExpectedSemanticError<SemanticError::InvalidUserDefinedProgramEntryPointModuleIdentifier>(Message::Position(0, 0), userDefinedExpectedMainModuleIdentifier);
+    performTestExecution("module main(out b[1](16)) skip", parserConfiguration);
+}
+
 TEST_F(SyrecParserErrorTestsFixture, DuplicateDeclarationOfModuleUsingSameInParameterTypeCausesError) {
     buildAndRecordExpectedSemanticError<SemanticError::DuplicateModuleDeclaration>(Message::Position(1, 63), "add");
     performTestExecution("module add(in a(4), in b(4), out res(4)) res ^= (a + b) module add(in lOp(4), in rOp(4), out res(4)) res += lOp; res += rOp");

--- a/test/unittests/test_properties.cpp
+++ b/test/unittests/test_properties.cpp
@@ -166,12 +166,13 @@ TEST(PropertiesTest, RemoveNotExistingEntry) {
     ASSERT_TRUE(propertiesLookup.containsKey(keyTwo));
     ASSERT_TRUE(propertiesLookup.containsKey(keyThree));
 
-    ASSERT_FALSE(propertiesLookup.remove("key_four"));
+    const std::string& notExistingKey = "key_four";
+    ASSERT_FALSE(propertiesLookup.remove(notExistingKey));
 
     ASSERT_TRUE(propertiesLookup.containsKey(keyOne));
     ASSERT_TRUE(propertiesLookup.containsKey(keyTwo));
     ASSERT_TRUE(propertiesLookup.containsKey(keyThree));
-    ASSERT_TRUE(propertiesLookup.containsKey("key_four"));
+    ASSERT_FALSE(propertiesLookup.containsKey(notExistingKey));
 
     ASSERT_NO_FATAL_FAILURE(assertValueForKeyMatches<std::string>(propertiesLookup, keyOne, expectedKeyOneValue));
     ASSERT_NO_FATAL_FAILURE(assertValueForKeyMatches<unsigned int>(propertiesLookup, keyTwo, expectedKeyTwoValue));

--- a/test/unittests/test_properties.cpp
+++ b/test/unittests/test_properties.cpp
@@ -373,10 +373,10 @@ TEST(PropertiesTest, UpdateValueOfExistingEntryWithValueOfAssignableTypePossible
 }
 
 TEST(PropertiesTest, GetValueOfEntryInInvalidLookupMapUsingLookupFunctionAcceptingSmartPointer) {
-    Properties::ptr        invalidLookupMap     = nullptr;
+    const Properties::ptr  invalidLookupMap     = nullptr;
     constexpr unsigned int expectedDefaultValue = 2U;
 
-    unsigned int actualFetchedValue;
+    unsigned int actualFetchedValue = 0U;
     ASSERT_NO_FATAL_FAILURE(actualFetchedValue = get<unsigned int>(invalidLookupMap, "key_one", expectedDefaultValue));
     ASSERT_EQ(expectedDefaultValue, actualFetchedValue);
 }

--- a/test/unittests/test_properties.cpp
+++ b/test/unittests/test_properties.cpp
@@ -1,0 +1,434 @@
+/*
+ * Copyright (c) 2023 - 2025 Chair for Design Automation, TUM
+ * Copyright (c) 2025 Munich Quantum Software Company GmbH
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License
+ */
+
+#include "core/properties.hpp"
+
+#include <any>
+#include <gtest/gtest.h>
+#include <memory>
+#include <optional>
+#include <string>
+
+using namespace syrec;
+
+namespace {
+    struct BaseType {
+        unsigned int value = 1U;
+    };
+
+    struct DerivedType: BaseType {
+        unsigned int otherValue = 2U;
+    };
+
+    constexpr bool operator==(const BaseType& lOperand, const BaseType& rOperand) noexcept {
+        return lOperand.value == rOperand.value;
+    }
+
+    constexpr bool operator==(const DerivedType& lOperand, const DerivedType& rOperand) noexcept {
+        return lOperand.value == rOperand.value && lOperand.otherValue == rOperand.otherValue;
+    }
+
+    template<typename T>
+    void assertValueForKeyMatches(const Properties& propertiesMap, const std::string& key, const std::optional<T>& expectedValue) {
+        std::optional<T> actualValue;
+        ASSERT_NO_FATAL_FAILURE(actualValue = propertiesMap.get<T>(key)) << "Value of entry with key '" << key << "' should be fetchable without errors";
+        if (expectedValue.has_value()) {
+            ASSERT_TRUE(actualValue.has_value());
+            ASSERT_EQ(*expectedValue, *actualValue);
+        } else {
+            ASSERT_FALSE(actualValue.has_value());
+        }
+    }
+} // namespace
+
+TEST(PropertiesTest, GetValueOfNotExistingEntryWithoutDefaultValue) {
+    const std::string& key   = "key_one";
+    const std::string& value = "value";
+
+    Properties propertiesLookup;
+    ASSERT_NO_FATAL_FAILURE(propertiesLookup.set(key, value));
+    ASSERT_NO_FATAL_FAILURE(assertValueForKeyMatches<std::string>(propertiesLookup, "key_two", std::nullopt));
+}
+
+TEST(PropertiesTest, GetValueOfEntryUsingKeyWithoutDefaultValue) {
+    const std::string& key   = "key_one";
+    const std::string& value = "value";
+
+    Properties propertiesLookup;
+    ASSERT_NO_FATAL_FAILURE(propertiesLookup.set(key, value));
+    ASSERT_NO_FATAL_FAILURE(assertValueForKeyMatches<std::string>(propertiesLookup, key, value));
+}
+
+TEST(PropertiesTest, GetValueOfNotExistingEntryWithDefaultValue) {
+    const std::string& key          = "key_one";
+    const std::string& value        = "value";
+    const std::string& defaultValue = "otherValue";
+
+    Properties propertiesLookup;
+    ASSERT_NO_FATAL_FAILURE(propertiesLookup.set(key, value));
+
+    std::string fetchedValue;
+    ASSERT_NO_FATAL_FAILURE(fetchedValue = propertiesLookup.get<std::string>("key_two", defaultValue));
+    ASSERT_EQ(defaultValue, fetchedValue);
+}
+
+TEST(PropertiesTest, GetValueOfNotExistingEntryWithDefaultValueOfDerivedTypeCausesError) {
+    const std::string&    key = "key_one";
+    constexpr BaseType    value;
+    constexpr DerivedType defaultValue = {{4U}};
+
+    Properties propertiesLookup;
+    ASSERT_NO_FATAL_FAILURE(propertiesLookup.set(key, value));
+    ASSERT_THROW(propertiesLookup.get<DerivedType>(key, defaultValue), std::bad_any_cast);
+}
+
+TEST(PropertiesTest, GetValueOfNotExistingEntryWithDefaultValueOfAssignableTypeCausesError) {
+    const std::string&     key          = "key_one";
+    constexpr unsigned int value        = 2U;
+    constexpr unsigned int defaultValue = 4U;
+
+    Properties propertiesLookup;
+    ASSERT_NO_FATAL_FAILURE(propertiesLookup.set(key, value));
+    ASSERT_THROW(propertiesLookup.get<int>(key, defaultValue), std::bad_any_cast);
+}
+
+TEST(PropertiesTest, GetValueOfEntryUsingKeyWithDefaultValueReturnsValueOfEntry) {
+    const std::string& key          = "key_one";
+    const std::string& value        = "value";
+    const std::string& defaultValue = "otherValue";
+
+    Properties propertiesLookup;
+    ASSERT_NO_FATAL_FAILURE(propertiesLookup.set(key, value));
+
+    std::string fetchedValue;
+    ASSERT_NO_FATAL_FAILURE(fetchedValue = propertiesLookup.get<std::string>(key, defaultValue));
+    ASSERT_EQ(value, fetchedValue);
+}
+
+TEST(PropertiesTest, CheckWhetherContainerContainsEntryUsingKeyOfNotExistingEntry) {
+    const std::string& keyOne   = "key_one";
+    const std::string& keyTwo   = "key_two";
+    const std::string& keyThree = "keyOne";
+
+    const std::string      keyOneValue   = "value";
+    constexpr unsigned int keyTwoValue   = 2U;
+    constexpr float        keyThreeValue = 3;
+
+    Properties propertiesLookup;
+    ASSERT_NO_FATAL_FAILURE(propertiesLookup.set(keyOne, keyOneValue));
+    ASSERT_NO_FATAL_FAILURE(propertiesLookup.set(keyTwo, keyTwoValue));
+    ASSERT_NO_FATAL_FAILURE(propertiesLookup.set(keyThree, keyThreeValue));
+
+    ASSERT_FALSE(propertiesLookup.containsKey("key_four"));
+}
+
+TEST(PropertiesTest, CheckWhetherContainerContainsEntryUsingKeyOfExistingEntry) {
+    const std::string& keyOne   = "key_one";
+    const std::string& keyTwo   = "key_two";
+    const std::string& keyThree = "keyOne";
+
+    const std::string      keyOneValue   = "value";
+    constexpr unsigned int keyTwoValue   = 2U;
+    constexpr float        keyThreeValue = 3;
+
+    Properties propertiesLookup;
+    ASSERT_NO_FATAL_FAILURE(propertiesLookup.set(keyOne, keyOneValue));
+    ASSERT_NO_FATAL_FAILURE(propertiesLookup.set(keyTwo, keyTwoValue));
+    ASSERT_NO_FATAL_FAILURE(propertiesLookup.set(keyThree, keyThreeValue));
+
+    ASSERT_TRUE(propertiesLookup.containsKey(keyOne));
+    ASSERT_TRUE(propertiesLookup.containsKey(keyTwo));
+    ASSERT_TRUE(propertiesLookup.containsKey(keyThree));
+}
+
+TEST(PropertiesTest, RemoveNotExistingEntry) {
+    const std::string& keyOne   = "key_one";
+    const std::string& keyTwo   = "key_two";
+    const std::string& keyThree = "keyOne";
+
+    const std::string&     expectedKeyOneValue   = "value";
+    constexpr unsigned int expectedKeyTwoValue   = 2U;
+    constexpr float        expectedKeyThreeValue = 3;
+
+    Properties propertiesLookup;
+    ASSERT_NO_FATAL_FAILURE(propertiesLookup.set(keyOne, expectedKeyOneValue));
+    ASSERT_NO_FATAL_FAILURE(propertiesLookup.set(keyTwo, expectedKeyTwoValue));
+    ASSERT_NO_FATAL_FAILURE(propertiesLookup.set(keyThree, expectedKeyThreeValue));
+
+    ASSERT_TRUE(propertiesLookup.containsKey(keyOne));
+    ASSERT_TRUE(propertiesLookup.containsKey(keyTwo));
+    ASSERT_TRUE(propertiesLookup.containsKey(keyThree));
+
+    ASSERT_FALSE(propertiesLookup.remove("key_four"));
+
+    ASSERT_TRUE(propertiesLookup.containsKey(keyOne));
+    ASSERT_TRUE(propertiesLookup.containsKey(keyTwo));
+    ASSERT_TRUE(propertiesLookup.containsKey(keyThree));
+    ASSERT_TRUE(propertiesLookup.containsKey("key_four"));
+
+    ASSERT_NO_FATAL_FAILURE(assertValueForKeyMatches<std::string>(propertiesLookup, keyOne, expectedKeyOneValue));
+    ASSERT_NO_FATAL_FAILURE(assertValueForKeyMatches<unsigned int>(propertiesLookup, keyTwo, expectedKeyTwoValue));
+    ASSERT_NO_FATAL_FAILURE(assertValueForKeyMatches<float>(propertiesLookup, keyThree, expectedKeyThreeValue));
+}
+
+TEST(PropertiesTest, RemoveExistingEntry) {
+    const std::string& keyOne   = "key_one";
+    const std::string& keyTwo   = "key_two";
+    const std::string& keyThree = "keyOne";
+
+    const std::string&     expectedKeyOneValue   = "value";
+    constexpr unsigned int expectedKeyTwoValue   = 2U;
+    constexpr float        expectedKeyThreeValue = 3;
+
+    Properties propertiesLookup;
+    ASSERT_NO_FATAL_FAILURE(propertiesLookup.set(keyOne, expectedKeyOneValue));
+    ASSERT_NO_FATAL_FAILURE(propertiesLookup.set(keyTwo, expectedKeyTwoValue));
+    ASSERT_NO_FATAL_FAILURE(propertiesLookup.set(keyThree, expectedKeyThreeValue));
+
+    ASSERT_TRUE(propertiesLookup.containsKey(keyOne));
+    ASSERT_TRUE(propertiesLookup.containsKey(keyTwo));
+    ASSERT_TRUE(propertiesLookup.containsKey(keyThree));
+
+    ASSERT_NO_FATAL_FAILURE(assertValueForKeyMatches<std::string>(propertiesLookup, keyOne, expectedKeyOneValue));
+    ASSERT_NO_FATAL_FAILURE(assertValueForKeyMatches<unsigned int>(propertiesLookup, keyTwo, expectedKeyTwoValue));
+    ASSERT_NO_FATAL_FAILURE(assertValueForKeyMatches<float>(propertiesLookup, keyThree, expectedKeyThreeValue));
+
+    ASSERT_TRUE(propertiesLookup.remove(keyOne));
+
+    ASSERT_FALSE(propertiesLookup.containsKey(keyOne));
+    ASSERT_TRUE(propertiesLookup.containsKey(keyTwo));
+    ASSERT_TRUE(propertiesLookup.containsKey(keyThree));
+
+    ASSERT_NO_FATAL_FAILURE(assertValueForKeyMatches<std::string>(propertiesLookup, keyOne, std::nullopt));
+    ASSERT_NO_FATAL_FAILURE(assertValueForKeyMatches<unsigned int>(propertiesLookup, keyTwo, expectedKeyTwoValue));
+    ASSERT_NO_FATAL_FAILURE(assertValueForKeyMatches<float>(propertiesLookup, keyThree, expectedKeyThreeValue));
+
+    ASSERT_TRUE(propertiesLookup.remove(keyTwo));
+
+    ASSERT_FALSE(propertiesLookup.containsKey(keyOne));
+    ASSERT_FALSE(propertiesLookup.containsKey(keyTwo));
+    ASSERT_TRUE(propertiesLookup.containsKey(keyThree));
+
+    ASSERT_NO_FATAL_FAILURE(assertValueForKeyMatches<std::string>(propertiesLookup, keyOne, std::nullopt));
+    ASSERT_NO_FATAL_FAILURE(assertValueForKeyMatches<unsigned int>(propertiesLookup, keyTwo, std::nullopt));
+    ASSERT_NO_FATAL_FAILURE(assertValueForKeyMatches<float>(propertiesLookup, keyThree, expectedKeyThreeValue));
+
+    ASSERT_TRUE(propertiesLookup.remove(keyThree));
+
+    ASSERT_FALSE(propertiesLookup.containsKey(keyOne));
+    ASSERT_FALSE(propertiesLookup.containsKey(keyTwo));
+    ASSERT_FALSE(propertiesLookup.containsKey(keyThree));
+
+    ASSERT_NO_FATAL_FAILURE(assertValueForKeyMatches<std::string>(propertiesLookup, keyOne, std::nullopt));
+    ASSERT_NO_FATAL_FAILURE(assertValueForKeyMatches<unsigned int>(propertiesLookup, keyTwo, std::nullopt));
+    ASSERT_NO_FATAL_FAILURE(assertValueForKeyMatches<float>(propertiesLookup, keyThree, std::nullopt));
+}
+
+TEST(PropertiesTest, SetNewEntry) {
+    const std::string& keyOne   = "key_one";
+    const std::string& keyTwo   = "key_two";
+    const std::string& keyThree = "keyOne";
+
+    const std::string&     expectedKeyOneValue   = "value";
+    constexpr unsigned int expectedKeyTwoValue   = 2U;
+    constexpr float        expectedKeyThreeValue = 3;
+
+    Properties propertiesLookup;
+    ASSERT_NO_FATAL_FAILURE(propertiesLookup.set(keyOne, expectedKeyOneValue));
+    ASSERT_NO_FATAL_FAILURE(propertiesLookup.set(keyThree, expectedKeyThreeValue));
+
+    ASSERT_TRUE(propertiesLookup.containsKey(keyOne));
+    ASSERT_FALSE(propertiesLookup.containsKey(keyTwo));
+    ASSERT_TRUE(propertiesLookup.containsKey(keyThree));
+
+    ASSERT_NO_FATAL_FAILURE(assertValueForKeyMatches<std::string>(propertiesLookup, keyOne, expectedKeyOneValue));
+    ASSERT_NO_FATAL_FAILURE(assertValueForKeyMatches<float>(propertiesLookup, keyThree, expectedKeyThreeValue));
+
+    ASSERT_NO_FATAL_FAILURE(propertiesLookup.set(keyTwo, expectedKeyTwoValue));
+
+    ASSERT_TRUE(propertiesLookup.containsKey(keyOne));
+    ASSERT_TRUE(propertiesLookup.containsKey(keyTwo));
+    ASSERT_TRUE(propertiesLookup.containsKey(keyThree));
+
+    ASSERT_NO_FATAL_FAILURE(assertValueForKeyMatches<std::string>(propertiesLookup, keyOne, expectedKeyOneValue));
+    ASSERT_NO_FATAL_FAILURE(assertValueForKeyMatches<unsigned int>(propertiesLookup, keyTwo, expectedKeyTwoValue));
+    ASSERT_NO_FATAL_FAILURE(assertValueForKeyMatches<float>(propertiesLookup, keyThree, expectedKeyThreeValue));
+}
+
+TEST(PropertiesTest, UpdateValueOfExistingEntry) {
+    const std::string& keyOne = "key_one";
+    const std::string& keyTwo = "keyOne";
+
+    const std::string& expectedKeyOneValue        = "value";
+    constexpr float    expectedKeyTwoInitialValue = 3;
+    constexpr float    expectedKeyTwoFinalValue   = 4;
+
+    Properties propertiesLookup;
+    ASSERT_NO_FATAL_FAILURE(propertiesLookup.set(keyOne, expectedKeyOneValue));
+    ASSERT_NO_FATAL_FAILURE(propertiesLookup.set(keyTwo, expectedKeyTwoInitialValue));
+
+    ASSERT_TRUE(propertiesLookup.containsKey(keyOne));
+    ASSERT_TRUE(propertiesLookup.containsKey(keyTwo));
+
+    ASSERT_NO_FATAL_FAILURE(assertValueForKeyMatches<std::string>(propertiesLookup, keyOne, expectedKeyOneValue));
+    ASSERT_NO_FATAL_FAILURE(assertValueForKeyMatches<float>(propertiesLookup, keyTwo, expectedKeyTwoInitialValue));
+
+    ASSERT_NO_FATAL_FAILURE(propertiesLookup.set(keyTwo, expectedKeyTwoFinalValue));
+
+    ASSERT_TRUE(propertiesLookup.containsKey(keyOne));
+    ASSERT_TRUE(propertiesLookup.containsKey(keyTwo));
+
+    ASSERT_NO_FATAL_FAILURE(assertValueForKeyMatches<std::string>(propertiesLookup, keyOne, expectedKeyOneValue));
+    ASSERT_NO_FATAL_FAILURE(assertValueForKeyMatches<float>(propertiesLookup, keyTwo, expectedKeyTwoFinalValue));
+}
+
+TEST(PropertiesTest, UpdateValueOfExistingEntryWithValueOfIncompatibleTypePossible) {
+    const std::string& keyOne = "key_one";
+    const std::string& keyTwo = "keyOne";
+
+    const std::string& expectedKeyOneValue        = "value";
+    constexpr float    expectedInitialKeyTwoValue = 3;
+
+    Properties propertiesLookup;
+    ASSERT_NO_FATAL_FAILURE(propertiesLookup.set(keyOne, expectedKeyOneValue));
+    ASSERT_NO_FATAL_FAILURE(propertiesLookup.set(keyTwo, expectedInitialKeyTwoValue));
+
+    ASSERT_TRUE(propertiesLookup.containsKey(keyOne));
+    ASSERT_TRUE(propertiesLookup.containsKey(keyTwo));
+
+    ASSERT_NO_FATAL_FAILURE(assertValueForKeyMatches<std::string>(propertiesLookup, keyOne, expectedKeyOneValue));
+    ASSERT_NO_FATAL_FAILURE(assertValueForKeyMatches<float>(propertiesLookup, keyTwo, expectedInitialKeyTwoValue));
+
+    const std::string& expectedFinalKeyTwoValue = "anotherValue";
+    ASSERT_NO_FATAL_FAILURE(propertiesLookup.set(keyTwo, expectedFinalKeyTwoValue));
+
+    ASSERT_TRUE(propertiesLookup.containsKey(keyOne));
+    ASSERT_TRUE(propertiesLookup.containsKey(keyTwo));
+
+    ASSERT_NO_FATAL_FAILURE(assertValueForKeyMatches<std::string>(propertiesLookup, keyOne, expectedKeyOneValue));
+    ASSERT_NO_FATAL_FAILURE(assertValueForKeyMatches<std::string>(propertiesLookup, keyTwo, expectedFinalKeyTwoValue));
+}
+
+TEST(PropertiesTest, UpdateValueOfExistingEntryWithValueOfDerivedTypePossible) {
+    const std::string& keyOne = "key_one";
+    const std::string& keyTwo = "keyOne";
+
+    const std::string& expectedKeyOneValue        = "value";
+    constexpr auto     expectedInitialKeyTwoValue = BaseType();
+
+    Properties propertiesLookup;
+    ASSERT_NO_FATAL_FAILURE(propertiesLookup.set(keyOne, expectedKeyOneValue));
+    ASSERT_NO_FATAL_FAILURE(propertiesLookup.set(keyTwo, expectedInitialKeyTwoValue));
+
+    ASSERT_TRUE(propertiesLookup.containsKey(keyOne));
+    ASSERT_TRUE(propertiesLookup.containsKey(keyTwo));
+
+    ASSERT_NO_FATAL_FAILURE(assertValueForKeyMatches<std::string>(propertiesLookup, keyOne, expectedKeyOneValue));
+    ASSERT_NO_FATAL_FAILURE(assertValueForKeyMatches<BaseType>(propertiesLookup, keyTwo, expectedInitialKeyTwoValue));
+
+    constexpr auto updateKeyTwoValue = DerivedType();
+    ASSERT_NO_FATAL_FAILURE(propertiesLookup.set(keyTwo, updateKeyTwoValue));
+
+    ASSERT_TRUE(propertiesLookup.containsKey(keyOne));
+    ASSERT_TRUE(propertiesLookup.containsKey(keyTwo));
+
+    ASSERT_NO_FATAL_FAILURE(assertValueForKeyMatches<std::string>(propertiesLookup, keyOne, expectedKeyOneValue));
+    ASSERT_NO_FATAL_FAILURE(assertValueForKeyMatches<DerivedType>(propertiesLookup, keyTwo, updateKeyTwoValue));
+
+    ASSERT_THROW(propertiesLookup.get<BaseType>(keyTwo), std::bad_any_cast);
+}
+
+TEST(PropertiesTest, UpdateValueOfExistingEntryWithValueOfAssignableTypePossible) {
+    const std::string& keyOne = "key_one";
+    const std::string& keyTwo = "keyOne";
+
+    const std::string& expectedKeyOneValue        = "value";
+    constexpr float    expectedInitialKeyTwoValue = 3;
+
+    Properties propertiesLookup;
+    ASSERT_NO_FATAL_FAILURE(propertiesLookup.set(keyOne, expectedKeyOneValue));
+    ASSERT_NO_FATAL_FAILURE(propertiesLookup.set(keyTwo, expectedInitialKeyTwoValue));
+
+    ASSERT_TRUE(propertiesLookup.containsKey(keyOne));
+    ASSERT_TRUE(propertiesLookup.containsKey(keyTwo));
+
+    ASSERT_NO_FATAL_FAILURE(assertValueForKeyMatches<std::string>(propertiesLookup, keyOne, expectedKeyOneValue));
+    ASSERT_NO_FATAL_FAILURE(assertValueForKeyMatches<float>(propertiesLookup, keyTwo, expectedInitialKeyTwoValue));
+
+    constexpr unsigned int expectedFinalKeyTwoValue = 2U;
+    ASSERT_NO_FATAL_FAILURE(propertiesLookup.set(keyTwo, expectedFinalKeyTwoValue));
+
+    ASSERT_TRUE(propertiesLookup.containsKey(keyOne));
+    ASSERT_TRUE(propertiesLookup.containsKey(keyTwo));
+
+    ASSERT_NO_FATAL_FAILURE(assertValueForKeyMatches<std::string>(propertiesLookup, keyOne, expectedKeyOneValue));
+    ASSERT_NO_FATAL_FAILURE(assertValueForKeyMatches<unsigned int>(propertiesLookup, keyTwo, expectedFinalKeyTwoValue));
+}
+
+TEST(PropertiesTest, GetValueOfEntryInInvalidLookupMapUsingLookupFunctionAcceptingSmartPointer) {
+    Properties::ptr        invalidLookupMap     = nullptr;
+    constexpr unsigned int expectedDefaultValue = 2U;
+
+    unsigned int actualFetchedValue;
+    ASSERT_NO_FATAL_FAILURE(actualFetchedValue = get<unsigned int>(invalidLookupMap, "key_one", expectedDefaultValue));
+    ASSERT_EQ(expectedDefaultValue, actualFetchedValue);
+}
+
+TEST(PropertiesTest, GetValueOfEntryUsingKeyWithoutMatchesUsingLookupFunctionAcceptingSmartPointer) {
+    auto               propertiesLookup    = std::make_shared<Properties>();
+    const std::string& keyOne              = "key_one";
+    const std::string& expectedKeyOneValue = "value";
+    ASSERT_NO_FATAL_FAILURE(propertiesLookup->set(keyOne, expectedKeyOneValue));
+    ASSERT_NO_FATAL_FAILURE(assertValueForKeyMatches<std::string>(*propertiesLookup, keyOne, expectedKeyOneValue));
+
+    const std::string& expectedDefaultValue = "defaultValue";
+    std::string        actualFetchedValue;
+    ASSERT_NO_FATAL_FAILURE(actualFetchedValue = get<std::string>(propertiesLookup, "key_two", expectedDefaultValue));
+    ASSERT_EQ(expectedDefaultValue, actualFetchedValue);
+}
+
+TEST(PropertiesTest, GetValueOfEntryUsingKeyUsingLookupFunctionAcceptingSmartPointer) {
+    auto               propertiesLookup    = std::make_shared<Properties>();
+    const std::string& keyOne              = "key_one";
+    const std::string& expectedKeyOneValue = "value";
+    ASSERT_NO_FATAL_FAILURE(propertiesLookup->set(keyOne, expectedKeyOneValue));
+    ASSERT_NO_FATAL_FAILURE(assertValueForKeyMatches<std::string>(*propertiesLookup, keyOne, expectedKeyOneValue));
+
+    const std::string& keyTwo              = "key_two";
+    const std::string& expectedKeyTwoValue = "otherValue";
+    ASSERT_NO_FATAL_FAILURE(propertiesLookup->set(keyTwo, expectedKeyTwoValue));
+    ASSERT_NO_FATAL_FAILURE(assertValueForKeyMatches<std::string>(*propertiesLookup, keyOne, expectedKeyOneValue));
+    ASSERT_NO_FATAL_FAILURE(assertValueForKeyMatches<std::string>(*propertiesLookup, keyTwo, expectedKeyTwoValue));
+
+    std::string actualKeyOneValue;
+    ASSERT_NO_FATAL_FAILURE(actualKeyOneValue = get<std::string>(propertiesLookup, keyOne, "OTHER"));
+    ASSERT_EQ(expectedKeyOneValue, actualKeyOneValue);
+
+    std::string actualKeyTwoValue;
+    ASSERT_NO_FATAL_FAILURE(actualKeyTwoValue = get<std::string>(propertiesLookup, keyTwo, "OTHER"));
+    ASSERT_EQ(expectedKeyTwoValue, actualKeyTwoValue);
+}
+
+TEST(PropertiesTest, GetValueOfEntryInLookupMapWithInvalidValueTypeUsingLookupFunctionAcceptingSmartPointer) {
+    auto               propertiesLookup = std::make_shared<Properties>();
+    const std::string& keyOne           = "key_one";
+    constexpr BaseType expectedKeyOneValue;
+    ASSERT_NO_FATAL_FAILURE(propertiesLookup->set(keyOne, expectedKeyOneValue));
+    ASSERT_NO_FATAL_FAILURE(assertValueForKeyMatches<BaseType>(*propertiesLookup, keyOne, expectedKeyOneValue));
+
+    const std::string& keyTwo              = "key_two";
+    const std::string& expectedKeyTwoValue = "otherValue";
+    ASSERT_NO_FATAL_FAILURE(propertiesLookup->set(keyTwo, expectedKeyTwoValue));
+    ASSERT_NO_FATAL_FAILURE(assertValueForKeyMatches<BaseType>(*propertiesLookup, keyOne, expectedKeyOneValue));
+    ASSERT_NO_FATAL_FAILURE(assertValueForKeyMatches<std::string>(*propertiesLookup, keyTwo, expectedKeyTwoValue));
+
+    ASSERT_THROW(get<DerivedType>(propertiesLookup, keyOne, DerivedType()), std::bad_any_cast);
+    ASSERT_THROW(get<unsigned int>(propertiesLookup, keyOne, 2U), std::bad_any_cast);
+}


### PR DESCRIPTION
## Description

As discussed in #265 this PR unifies the search for the main module of a SyReC program between the parser and synthesis algorithms into the following steps:

1. If the user defined an expected main module identifier in the `syrec::ReadProgramSettings` or `syrec::Properties`
   1.  Validate the user defined identifier
   2. If valid, find all modules that match the provided identifier
   3. If the number of matching modules is not equal to one -> _ERROR_, otherwise the main module is found.
2. If 1. did not find the main module due to no expected identifier being provided, search for all modules matching the identifier `main`
    1. More than one module matches the identifier `main` -> _ERROR_
    2. No module matches -> (GOTO 3.). 
    3. Otherwise, the main module is found.
4. Select the last defined module of the SyReC program as the main module.
5. If no main module was found -> _ERROR_

_Note: Comparison of module identifiers is case sensitive and must match the searched for string exactly._

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [X] The pull request only contains commits that are related to it.
- [X] I have added appropriate tests and documentation.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [X] The pull request introduces no new warnings and follows the project's style guidelines.
