### PR TITLE
📝 Fix rendering of documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -70,6 +70,7 @@ extensions = [
     "sphinx.ext.githubpages",
     "sphinxcontrib.bibtex",
     "sphinx_copybutton",
+    "sphinx_design",
     "nbsphinx",
     "sphinxext.opengraph",
     "sphinx_autodoc_typehints",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -95,6 +95,18 @@ intersphinx_mapping = {
     "qmap": ("https://mqt.readthedocs.io/projects/qmap/en/latest/", None),
 }
 
+myst_enable_extensions = [
+    "amsmath",
+    "colon_fence",
+    "deflist",
+    "dollarmath",
+    "substitution",
+]
+myst_substitutions = {
+    "version": version,
+}
+myst_heading_anchors = 3
+
 nbsphinx_execute = "auto"
 highlight_language = "python3"
 nbsphinx_execute_arguments = [
@@ -102,6 +114,7 @@ nbsphinx_execute_arguments = [
     "--InlineBackend.rc=figure.dpi=200",
 ]
 nbsphinx_kernel_name = "python3"
+nb_execution_raise_on_error = True
 
 autosectionlabel_prefix_document = True
 


### PR DESCRIPTION
## Description

This PR fixes the rendering of the installation guide by enabling the `colon_fence` extension to render MyST admonitions. In addition, the PR aligns the configuration with other MQT projects.

Fixes #370

## Checklist:

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~I have added appropriate tests that cover the new/changed functionality.~
- [x] ~I have updated the documentation to reflect these changes.~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
