### PR TITLE
📝 Remove stale CircuitOptimizer reference

### DIFF
--- a/include/core/annotatable_quantum_computation.hpp
+++ b/include/core/annotatable_quantum_computation.hpp
@@ -350,8 +350,8 @@ namespace syrec {
 
         QuantumOperationAnnotationsLookup activateGlobalQuantumOperationAnnotations;
 
-        // We are assuming that no operations in the qc::QuantumComputation are removed (i.e. by applying qc::CircuitOptimizer) and will thus use the index of the quantum operation
-        // as the search key in the container storing the annotations per quantum operation.
+        // We assume that no operations are removed from the qc::QuantumComputation after annotation.
+        // The operation index therefore remains a stable search key.
         std::vector<QuantumOperationAnnotationsLookup> annotationsPerQuantumOperation;
 
         /**


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Remove the stale CircuitOptimizer name from the annotation-index comment. The revised wording documents the actual invariant: operations must not be removed after annotation, so operation indices remain stable.

This small cleanup was identified while auditing downstream repositories for the MQT Core v4 CircuitOptimizer removal.

AI assistance: GPT-5.6 via Codex updated the comment, ran the repository lint suite, reviewed the resulting diff, and prepared this draft pull request.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~~I have added appropriate tests that cover the new/changed functionality.~~
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/syrec/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [ ] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.